### PR TITLE
fix: 이슈, PR과 프로젝트를 연결해주는 워크플로 오류 수정 (#12)

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -1,20 +1,26 @@
 name: Automate project assignments
-on: [issues, pull_request]
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
 jobs:
   github-actions-automate-projects:
     runs-on: ubuntu-latest
     steps:
       - name: add-new-issues-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
         if: github.event_name == 'issues' && github.event.action == 'opened'
+        uses: takanabe/github-actions-automate-projects@v0.0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.TOKEN }}
           GITHUB_PROJECT_URL: https://github.com/orgs/Dev-FE-1/projects/7
-          GITHUB_PROJECT_COLUMN_NAME: To do
+          GITHUB_PROJECT_COLUMN_NAME: Todo
+
       - name: add-new-prs-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        uses: takanabe/github-actions-automate-projects@v0.0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.TOKEN }}
           GITHUB_PROJECT_URL: https://github.com/orgs/Dev-FE-1/projects/7
-          GITHUB_PROJECT_COLUMN_NAME: To do
+          GITHUB_PROJECT_COLUMN_NAME: In Progress


### PR DESCRIPTION
- GITHUB_TOKEN이라는 이름을 사용할 수 없어 TOKEN으로 변경
- 이슈와 PR이 open될 때 동작하도록 명확하게 설정
- PR의 경우 In Progress로 추가하도록 수정