### PR TITLE
Title 컴포넌트 추가

### DIFF
--- a/src/components/Title/Title.css
+++ b/src/components/Title/Title.css
@@ -1,0 +1,30 @@
+.page-title-container {
+  padding-top: 30px;
+}
+
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 7002;
+}
+
+.page-subtitle {
+  margin-bottom: 8px;
+  font-size: 0.75rem;
+  color: var(--color-dark-gray);
+}
+
+.page-title-description {
+  margin-top: 2px;
+  font-size: 0.875rem;
+  color: var(--color-dark-gray);
+}
+
+@media (width >= 1024px) {
+  .page-title {
+    font-size: 1.5rem;
+  }
+
+  .page-subtitle {
+    font-size: 0.875rem;
+  }
+}

--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -1,0 +1,23 @@
+import './Title.css';
+
+export default class Title {
+  constructor({ title, subtitle, description, contents, desktopOnly }) {
+    this.title = title;
+    this.subtitle = subtitle || '';
+    this.description = description || '';
+    this.contents = contents || '';
+    this.desktopOnly = desktopOnly || '';
+  }
+
+  html() {
+    return `
+      <div class="page-title-container${this.desktopOnly && ' desktop-only'}">
+        <div class="wrapper">
+            ${this.subtitle && `<div class="page-subtitle">${this.subtitle}</div>`}
+            <h1 class="page-title">${this.title}</h1>
+            ${this.description && `<p class="page-title-description">${this.description}</p>`}
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -49,4 +49,10 @@ button {
   .main-container {
     padding: 60px 0 0 220px;
   }
+
+  .wrapper {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
 }

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,10 +1,21 @@
 import Main from '../../components/Main';
+import Title from '../../components/Title/Title';
 import './Home.css';
 
 export default class HomePage extends Main {
+  constructor() {
+    super();
+    this.Title = new Title({
+      title: '작은 큐브가 만드는 큰 변화, Cube.IT',
+      subtitle: 'VISION & MISSION',
+      description:
+        'Cube.IT은 작은 아이디어로 큰 변화를 만들어갑니다. 혁신적인 큐브의 힘을 경험해 보세요.',
+    });
+  }
+
   render() {
     this.$container.innerHTML = `
-        <h1>홈</h1>
+      ${this.Title.html()}
     `;
   }
 }

--- a/src/pages/Members/Members.js
+++ b/src/pages/Members/Members.js
@@ -1,10 +1,19 @@
 import Main from '../../components/Main';
+import Title from '../../components/Title/Title';
+import { MENUS } from '../../utils/constants';
 import './Members.css';
 
 export default class MembersPage extends Main {
+  constructor() {
+    super();
+    this.Title = new Title({
+      title: MENUS.MEMBERS,
+    });
+  }
+
   render() {
     this.$container.innerHTML = `
-        <h1>구성원</h1>
+      ${this.Title.html()}
     `;
   }
 }

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -1,10 +1,20 @@
 import Main from '../../components/Main';
+import Title from '../../components/Title/Title';
+import { MENUS } from '../../utils/constants';
 import './Profile.css';
 
 export default class ProfilePage extends Main {
+  constructor() {
+    super();
+    this.Title = new Title({
+      title: MENUS.PROFILE,
+      desktopOnly: true,
+    });
+  }
+
   render() {
     this.$container.innerHTML = `
-        <h1>프로필</h1>
+      ${this.Title.html()}
     `;
   }
 }

--- a/src/pages/WorkManage/WorkManage.js
+++ b/src/pages/WorkManage/WorkManage.js
@@ -1,10 +1,19 @@
 import Main from '../../components/Main';
+import Title from '../../components/Title/Title';
+import { MENUS } from '../../utils/constants';
 import './WorkManage.css';
 
 export default class WorkManagePage extends Main {
+  constructor() {
+    super();
+    this.Title = new Title({
+      title: MENUS.WORK_MANAGE,
+    });
+  }
+
   render() {
     this.$container.innerHTML = `
-        <h1>근무/휴가</h1>
+      ${this.Title.html()}
     `;
   }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

Title 컴포넌트 추가 후 각 페이지에 적용

## 📋 작업 내용

Title 컴포넌트를 만들어 각 페이지에 적용해뒀습니다.

## 🔧 변경 사항

- `index.css` 파일에 `.wrapper` 데스크탑 스타일 추가
- 각 페이지의 제목을 Title 컴포넌트로 변경

## 📸 스크린샷 (선택 사항)

![image](https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/48529e51-21ec-4c82-93e3-45a64bb36707)

## 📄 기타

홈 문구는 지피티한테 부탁해서 만들어봤어요 ㅋㅋㅋ
