### PR TITLE
[Feat] PersonalInfo 컴포넌트 추가

### DIFF
--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -9,19 +9,20 @@
 
 .profile-img {
   position: absolute;
-  left: -2px;
-  width: 40px;
+  top: 50%;
+  left: 50%;
+  width: 120%;
+  transform: translate(-50%, -50%);
 }
 
 .profile-img-container.img-large {
-  height: 120px;
-  width: 120px;
+  height: 140px;
+  width: 140px;
   border-radius: 30px;
 }
 
 .profile-img.img-large {
-  left: -15px;
-  width: 140px;
+  width: 100%;
 }
 
 .profile-img-container.img-bd-light {

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -9,9 +9,9 @@ export default class Avatar {
 
   html() {
     return `
-			<div class='profile-img-container img-${this.size} img-bd-${this.border}'>
-				<img src=${this.url} alt="프로필 사진" class="profile-img img-${this.size}"/>
-			</div>
+      <div class='profile-img-container img-${this.size} img-bd-${this.border}'>
+        <img src=${this.url} alt="프로필 사진" class="profile-img img-${this.size}"/>
+      </div>
     `;
   }
 }

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -3,8 +3,8 @@ import './Avatar.css';
 export default class Avatar {
   constructor({ url, size, border }) {
     this.url = url;
-    this.size = size || 'default'; //default, large
-    this.border = border || 'default'; //default, light
+    this.size = size || 'default'; // default, large
+    this.border = border || 'default'; // default, light
   }
 
   html() {

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -3,16 +3,13 @@
   border: 0;
   width: 100%;
   height: 50px;
-  font-size: 16;
+  font-size: 1rem;
+  transition: 0.2s;
 }
 
 .btn-primary {
   background-color: var(--color-primary);
   color: #fff;
-}
-
-.btn-primary:hover {
-  background-color: #0067d7;
 }
 
 .btn-primary:disabled {
@@ -25,10 +22,6 @@
   color: var(--color-black);
 }
 
-.btn-secondary:hover {
-  background-color: var(--color-dark-gray);
-}
-
 .btn-secondary:disabled {
   background-color: var(--color-lightest-gray);
   color: var(--color-dark-gray);
@@ -37,10 +30,6 @@
 .btn-tertiary {
   background-color: var(--color-lightest-gray);
   color: #333d4b;
-}
-
-.btn-tertiary:hover {
-  background-color: var(--color-dark-gray);
 }
 
 .btn-tertiary:disabled {
@@ -54,21 +43,35 @@
   border: 1px solid var(--color-light-gray);
 }
 
-.btn-ghost:hover {
-  border: 1px solid var(--color-primary);
-  color: var(--color-primary);
-}
-
 .btn-text {
   background-color: transparent;
   color: #8b95a1;
 }
 
-.btn-text:hover {
-  background-color: var(--color-light-gray);
-  color: var(--color-black);
-}
-
 .btn-small {
   height: 30px;
+}
+
+@media (width >= 1024px) {
+  .btn-primary:hover {
+    background-color: #0067d7;
+  }
+
+  .btn-secondary:hover {
+    background-color: var(--color-dark-gray);
+  }
+
+  .btn-tertiary:hover {
+    background-color: var(--color-dark-gray);
+  }
+
+  .btn-ghost:hover {
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+  }
+
+  .btn-text:hover {
+    background-color: var(--color-light-gray);
+    color: var(--color-black);
+  }
 }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,8 +2,8 @@ import './Button.css';
 
 export default class Button {
   constructor({ type, size, content }) {
-    this.type = type || 'primary'; //primary, secondary, tertiary, ghost, text
-    this.size = size || 'default'; //small
+    this.type = type || 'primary'; // primary, secondary, tertiary, ghost, text
+    this.size = size || 'default'; // small
     this.content = content || '';
   }
 

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -5,7 +5,6 @@ export default class Icon {
     this.svg = svg;
     this.color = options.color || COLORS.BLACK;
     this.size = options.size || '1rem';
-    this.icon = null;
   }
 
   html() {

--- a/src/components/PersonalInfo/PersonalInfo.css
+++ b/src/components/PersonalInfo/PersonalInfo.css
@@ -1,0 +1,11 @@
+.personal-info-section {
+  padding: 30px 0;
+  background-color: #fff;
+}
+
+@media (width >= 1024px) {
+  .personal-info-section .wrapper {
+    display: flex;
+    flex-basis: 0;
+  }
+}

--- a/src/components/PersonalInfo/PersonalInfo.js
+++ b/src/components/PersonalInfo/PersonalInfo.js
@@ -1,0 +1,47 @@
+import './PersonalInfo.css';
+import ProfileInfo from './ProfileInfo';
+import WorkInfo from './WorkInfo';
+
+const dummyUserProfile = {
+  employeeNumber: 101,
+  name: '안민지',
+  position: 'Software Engineer',
+  hireDate: '2015-10-11',
+  birthDate: '1987-05-08',
+  address: '경상북도 안산시 단원구 반포대거리',
+  email: 'anminji@cubeit.com',
+  phoneNumber: '010-7583-2446',
+  salary: 69000000,
+  isAdmin: false,
+  departmentNumber: 20,
+  education: '성균관대학교 소프트웨어공학 학사',
+  career: [
+    {
+      companyName: '카카오',
+      period: '2012-04-06 ~ 2014-07-02',
+      role: '백엔드 개발자',
+    },
+  ],
+  role: '백엔드 개발자',
+  profileImage:
+    'https://api.dicebear.com/9.x/lorelei/svg?seed=Max&eyes=variant09',
+  remainingVacationDays: 11,
+};
+
+export default class PersonalInfo {
+  constructor() {
+    this.ProfileInfo = new ProfileInfo({ user: dummyUserProfile });
+    this.WorkInfo = new WorkInfo();
+  }
+
+  html() {
+    return `
+      <section class="personal-info-section">
+        <div class="wrapper">
+          ${this.ProfileInfo.html()}
+          ${this.WorkInfo.html()}
+        </div>
+      </section>
+    `;
+  }
+}

--- a/src/components/PersonalInfo/ProfileInfo.css
+++ b/src/components/PersonalInfo/ProfileInfo.css
@@ -1,0 +1,50 @@
+.profile-info {
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.work-status-label {
+  position: relative;
+  width: 70px;
+  padding: 5px 8px 5px 24px;
+  border: 1px solid var(--color-lightest-gray);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  box-sizing: border-box;
+}
+
+.work-status-label::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 8px;
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: var(--color-light-gray);
+  transform: translateY(-50%);
+}
+
+.work-status-label.active::before {
+  background-color: var(--color-primary);
+}
+
+.personal-profile {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: 16px;
+}
+
+.profile-name {
+  margin-top: 8px;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+@media (width >= 1024px) {
+  .profile-info {
+    flex-grow: 1;
+  }
+}

--- a/src/components/PersonalInfo/ProfileInfo.js
+++ b/src/components/PersonalInfo/ProfileInfo.js
@@ -1,0 +1,26 @@
+import Avatar from '../Avatar/Avatar';
+import './ProfileInfo.css';
+
+export default class ProfileInfo {
+  constructor({ user }) {
+    this.user = user;
+    this.Avatar = new Avatar({
+      url: this.user.profileImage,
+      size: 'large',
+    });
+    this.isWorking = false;
+  }
+
+  html() {
+    return `
+      <div class="profile-info">
+        ${this.Avatar.html()}
+        <div class="personal-profile">
+          <div class="work-status-label${this.isWorking ? ' active' : ''}">${this.isWorking ? '근무중' : '근무전'}</div>
+          <h2 class="profile-name">${this.user.name}</h2>
+          <span>${this.user.role}</span>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/components/PersonalInfo/WorkInfo.css
+++ b/src/components/PersonalInfo/WorkInfo.css
@@ -1,0 +1,93 @@
+.work-info-container {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.work-info {
+  position: relative;
+  border: 1px solid var(--color-light-gray);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.daily-work-hours {
+  padding-bottom: 50px;
+  margin-bottom: 12px;
+}
+
+.work-hours-list {
+  display: flex;
+  flex-basis: 0;
+}
+
+.work-hours-list li {
+  flex-grow: 1;
+  padding: 24px 0;
+  text-align: center;
+}
+
+.work-hour-title {
+  font-size: 0.875rem;
+}
+
+.work-hour-time {
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+.work-hours-button-container button {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 0;
+}
+
+.weekly-work-hours {
+  padding: 16px;
+}
+
+.weekly-work-hours-title {
+  margin-top: 20px;
+  font-size: 0.875rem;
+}
+
+.weekly-work-hours-time {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.weekly-work-hours .clock-icon {
+  filter: contrast(20%);
+}
+
+@media (width >= 768px) {
+  .work-info-container {
+    flex-direction: row;
+    gap: 12px;
+    height: 140px;
+  }
+
+  .work-info {
+    flex-grow: 1;
+  }
+
+  .weekly-work-hours-title {
+    margin-top: 32px;
+  }
+
+  .daily-work-hours {
+    margin-bottom: 0;
+  }
+}
+
+@media (width >= 1024px) {
+  .work-info-container {
+    flex-grow: 2;
+    justify-content: flex-end;
+  }
+
+  .work-info {
+    max-width: 300px;
+  }
+}

--- a/src/components/PersonalInfo/WorkInfo.js
+++ b/src/components/PersonalInfo/WorkInfo.js
@@ -1,0 +1,54 @@
+import Button from '../Button/Button';
+import Icon from '../Icon/Icon';
+import ProgressRing from '../ProgressRing.js/ProgressRing';
+import { COLORS } from '../../utils/constants';
+import { clockIcon } from '../../utils/icons';
+import './WorkInfo.css';
+
+export default class WorkInfo {
+  constructor() {
+    this.weeklyWorkHours = 32;
+    this.Icon = new Icon({
+      svg: clockIcon,
+      options: { color: COLORS.DARK_GRAY },
+    });
+    this.ProgressRing = new ProgressRing({ percent: 50 });
+    this.Button = new Button({
+      type: 'secondary',
+      size: 'large',
+      content: '근무 시작',
+    });
+  }
+
+  html() {
+    return `
+      <div class="work-info-container">
+        <div class="work-info weekly-work-hours">
+          ${this.Icon.html()}
+          <div class="weekly-work-hours-title">이번 주 근무 시간</div>
+          <strong class="weekly-work-hours-time">${this.weeklyWorkHours}시간</strong>
+          ${this.ProgressRing.html()}
+        </div>
+        <div class="work-info daily-work-hours">
+          <ul class="work-hours-list">
+            <li>
+              <div class="work-hour-title">현재 시각</div>
+              <time class="work-hour-time" datetime="07:06">07:06</time>
+            </li>
+            <li>
+              <div class="work-hour-title">근무 시작</div>
+              <time class="work-hour-time" datetime="">-</time>
+            </li>
+            <li>
+              <div class="work-hour-title">근무 종료</div>
+              <time class="work-hour-time" datetime="">-</time>
+            </li>
+          </ul>
+          <div class="work-hours-button-container" type="button">
+            ${this.Button.html()}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/components/ProgressRing.js/ProgressRing.css
+++ b/src/components/ProgressRing.js/ProgressRing.css
@@ -1,0 +1,20 @@
+.progress-ring {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  width: 40px;
+  height: 40px;
+  transform: rotate(275deg);
+}
+
+.progress-bg {
+  stroke: var(--color-lightest-gray);
+  fill: none;
+}
+
+.progress-ing {
+  stroke: var(--color-primary);
+  fill: none;
+  stroke-linecap: round;
+  stroke-dasharray: 100;
+}

--- a/src/components/ProgressRing.js/ProgressRing.js
+++ b/src/components/ProgressRing.js/ProgressRing.js
@@ -1,0 +1,31 @@
+import './ProgressRing.css';
+
+export default class ProgressRing {
+  constructor({ percent }) {
+    this.dashoffset = 100 - percent;
+  }
+
+  html() {
+    return `
+      <div class="progress-ring">
+        <svg width="40" height="40" viewBox="0 0 40 40">
+          <circle
+            class="progress-bg"
+            cx="20"
+            cy="20"
+            r="16"
+            stroke-width="6"
+          />
+          <circle
+            class="progress-ing"
+            cx="20"
+            cy="20"
+            r="16"
+            stroke-width="6"
+            stroke-dashoffset="${this.dashoffset}"
+          />
+        </svg>
+      </div>
+    `;
+  }
+}

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -1,4 +1,5 @@
 import Main from '../../components/Main';
+import PersonalInfo from '../../components/PersonalInfo/PersonalInfo';
 import Title from '../../components/Title/Title';
 import { MENUS } from '../../utils/constants';
 import './Profile.css';
@@ -10,11 +11,13 @@ export default class ProfilePage extends Main {
       title: MENUS.PROFILE,
       desktopOnly: true,
     });
+    this.PersonalInfo = new PersonalInfo();
   }
 
   render() {
     this.$container.innerHTML = `
       ${this.Title.html()}
+      ${this.PersonalInfo.html()}
     `;
   }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

PersonalInfo 컴포넌트를 만들어 프로필 페이지에 출력했습니다.
유저 정보는 더미데이터를 사용했는데 시간은 우선 퍼블리싱만 해둔 상태입니다!

## 📋 작업 내용

- ProfileInfo 컴포넌트 추가
- WorkInfo 컴포넌트 추가
    - ProgressRing 컴포넌트 추가 
- PersonalInfo에 위의 두 컴포넌트 추가
- Profile 페이지에 출력

## 🔧 변경 사항

- Button 컴포넌트 수정
    - font-size가 단위 없이 16이라고 들어가 있어서 1rem으로 변경
    - hover 효과를 데스크탑에서만 적용되도록 미디어쿼리 추가 및 트랜지션 추가
    - Eslint 오류 수정
- Avatar 컴포넌트 수정
    - 약간의 스타일 수정 (large 사이즈 변경 등)
    - Eslint 오류 수정
- Icon 컴포넌트 불필요한 초기화 삭제 

## 📸 스크린샷 (선택 사항)

![image](https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/a9850e78-0318-44d9-866f-8dc4c510c434)
![image](https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/25bf23ea-d193-464b-b4d3-fd7510bbad36)

## 📄 기타

더미데이터는 제 원픽 안민지씨 ㅎㅎ