### PR TITLE
[Feat] 프로필 페이지 퍼블리싱

### DIFF
--- a/src/components/PersonalInfo/PersonalDetail.js
+++ b/src/components/PersonalInfo/PersonalDetail.js
@@ -15,17 +15,16 @@ export default class PersonalDetail {
                 ? this.info
                     .map(
                       (detail) => `
-                  <li>
-                    <h3 class="personal-detail-subtitle">${detail.subtitle}</h3>
-                    <span class="personal-detail-info">${detail.contents}</span>
-                  </li>
-                `,
+                        <li>
+                          <h3 class="personal-detail-subtitle">${detail.subtitle}</h3>
+                          <span class="personal-detail-info">${detail.contents}</span>
+                        </li>
+                      `,
                     )
                     .join('')
-                : ''
+                : '<li class="admin-owner-only">본인 혹은 관리자만 열람할 수 있습니다.</li>'
             }
           </ul>
-          ${!this.info.length ? '<p class="admin-owner-only-text">본인 혹은 관리자만 열람할 수 있습니다.</p>' : ''}
         </div>
       </li>
     `;

--- a/src/components/PersonalInfo/PersonalDetail.js
+++ b/src/components/PersonalInfo/PersonalDetail.js
@@ -1,0 +1,33 @@
+export default class PersonalDetail {
+  constructor({ title, info }) {
+    this.title = title;
+    this.info = info;
+  }
+
+  html() {
+    return `
+      <li>
+        <div class="wrapper">
+          <h2 class="personal-detail-title">${this.title}</h2>
+          <ul class="personal-detail-list">
+            ${
+              this.info.length
+                ? this.info
+                    .map(
+                      (detail) => `
+                  <li>
+                    <h3 class="personal-detail-subtitle">${detail.subtitle}</h3>
+                    <span class="personal-detail-info">${detail.contents}</span>
+                  </li>
+                `,
+                    )
+                    .join('')
+                : ''
+            }
+          </ul>
+          ${!this.info.length ? '<p class="admin-owner-only-text">본인 혹은 관리자만 열람할 수 있습니다.</p>' : ''}
+        </div>
+      </li>
+    `;
+  }
+}

--- a/src/components/PersonalInfo/PersonalDetails.css
+++ b/src/components/PersonalInfo/PersonalDetails.css
@@ -42,7 +42,8 @@
   font-size: 0.875rem;
 }
 
-.admin-owner-only-text {
+.personal-detail-list .admin-owner-only {
+  display: block;
   color: var(--color-dark-gray);
 }
 
@@ -95,7 +96,7 @@
     font-size: 1.125rem;
   }
 
-  .admin-owner-only-text {
+  .personal-detail-list .admin-owner-only {
     font-size: 0.875rem;
   }
 }

--- a/src/components/PersonalInfo/PersonalDetails.css
+++ b/src/components/PersonalInfo/PersonalDetails.css
@@ -1,0 +1,101 @@
+.personal-details-list > li {
+  padding: 30px 0;
+  margin-top: 12px;
+  background-color: #fff;
+}
+
+.personal-detail-title {
+  margin-bottom: 24px;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.personal-detail-list > li {
+  display: grid;
+  grid-template-columns: minmax(0, 110px) 2fr;
+  margin-bottom: 8px;
+}
+
+.personal-detail-list > li:last-child {
+  margin-bottom: 0;
+}
+
+.personal-detail-subtitle {
+  color: var(--color-darkest-gray);
+  font-weight: 500;
+}
+
+.career-list li:not(:last-child) {
+  margin-bottom: 8px;
+}
+
+.career-company {
+  font-weight: 500;
+}
+
+.career-period {
+  font-size: 0.75rem;
+}
+
+.career-role {
+  color: var(--color-dark-gray);
+  font-size: 0.875rem;
+}
+
+.admin-owner-only-text {
+  color: var(--color-dark-gray);
+}
+
+@media (width >= 1024px) {
+  .personal-details-section {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  .personal-details-list {
+    display: grid;
+    grid-auto-rows: minmax(150px, auto);
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-areas:
+      'details-1 details-3'
+      'details-2 details-4';
+  }
+
+  .personal-details-list > li:nth-child(1) {
+    grid-area: details-1;
+  }
+
+  .personal-details-list > li:nth-child(2) {
+    grid-area: details-2;
+  }
+
+  .personal-details-list > li:nth-child(3) {
+    grid-area: details-3;
+  }
+
+  .personal-details-list > li:nth-child(4) {
+    grid-area: details-4;
+  }
+
+  .personal-detail-list {
+    font-size: 0.875rem;
+  }
+
+  .personal-details-list > li {
+    padding: 30px 0;
+    margin: 0;
+  }
+
+  .personal-details-list > li:nth-child(1),
+  .personal-details-list > li:nth-child(3) {
+    padding-top: 20px;
+  }
+
+  .personal-detail-title {
+    font-size: 1.125rem;
+  }
+
+  .admin-owner-only-text {
+    font-size: 0.875rem;
+  }
+}

--- a/src/components/PersonalInfo/PersonalDetails.js
+++ b/src/components/PersonalInfo/PersonalDetails.js
@@ -1,0 +1,88 @@
+import PersonalDetail from './PersonalDetail';
+import './PersonalDetails.css';
+
+export default class PersonalDetails {
+  constructor({ user }) {
+    this.user = user;
+    this.isAdmin = user.isAdmin;
+    this.isOwner = true; // 임시
+    this.personalInfo = [];
+    this.privateInfo = [];
+    this.employmentInfo = [];
+    this.educationAndCareerInfo = [];
+    this.setInfoArray();
+  }
+
+  setInfoArray() {
+    this.personalInfo = [
+      { subtitle: '조직', contents: '검색시스템개발팀' }, // 임시
+      { subtitle: '직책', contents: this.user.role },
+    ];
+
+    this.privateInfo = [
+      { subtitle: '이메일', contents: this.user.email },
+      { subtitle: '전화번호', contents: this.user.phoneNumber },
+    ];
+
+    if (this.isAdmin || this.isOwner) {
+      this.privateInfo.unshift({
+        subtitle: '생년월일',
+        contents: this.user.birthDate,
+      });
+
+      this.privateInfo.push({
+        subtitle: '자택 주소',
+        contents: this.user.address,
+      });
+
+      this.employmentInfo = [
+        { subtitle: '입사일', contents: this.user.hireDate },
+        { subtitle: '근무유형', contents: '정규직' }, // 임시
+      ];
+
+      this.educationAndCareerInfo = [
+        { subtitle: '학력', contents: this.user.education },
+        {
+          subtitle: '경력',
+          contents: `<ul class="career-list">
+            ${
+              this.user.career.length
+                ? this.user.career
+                    .map(
+                      (career) => `
+                        <li>
+                          <strong class="career-company">${career.companyName}</strong>
+                          <div class="career-period">(${career.period})</div>
+                          <div class="career-role">${career.role}</div>
+                        </li>
+                      `,
+                    )
+                    .join('')
+                : '<li>없음</li>'
+            }
+          </ul>`,
+        },
+      ];
+    }
+
+    if (this.isAdmin) {
+      this.employmentInfo.push({
+        subtitle: '연봉',
+        contents: this.user.salary.toLocaleString('en-US'),
+      });
+    }
+  }
+
+  html() {
+    return `
+      <section class="personal-details-section">
+        <ul class="personal-details-list">
+          ${new PersonalDetail({ title: '인사정보', info: this.personalInfo }).html()}
+          ${new PersonalDetail({ title: '개인정보', info: this.privateInfo }).html()}
+          ${new PersonalDetail({ title: '고용정보', info: this.employmentInfo }).html()}
+          ${new PersonalDetail({ title: '학력/경력', info: this.educationAndCareerInfo }).html()}
+        </ul>
+      </section>
+    `;
+  }
+}

--- a/src/components/PersonalInfo/PersonalInfo.js
+++ b/src/components/PersonalInfo/PersonalInfo.js
@@ -2,35 +2,9 @@ import './PersonalInfo.css';
 import ProfileInfo from './ProfileInfo';
 import WorkInfo from './WorkInfo';
 
-const dummyUserProfile = {
-  employeeNumber: 101,
-  name: '안민지',
-  position: 'Software Engineer',
-  hireDate: '2015-10-11',
-  birthDate: '1987-05-08',
-  address: '경상북도 안산시 단원구 반포대거리',
-  email: 'anminji@cubeit.com',
-  phoneNumber: '010-7583-2446',
-  salary: 69000000,
-  isAdmin: false,
-  departmentNumber: 20,
-  education: '성균관대학교 소프트웨어공학 학사',
-  career: [
-    {
-      companyName: '카카오',
-      period: '2012-04-06 ~ 2014-07-02',
-      role: '백엔드 개발자',
-    },
-  ],
-  role: '백엔드 개발자',
-  profileImage:
-    'https://api.dicebear.com/9.x/lorelei/svg?seed=Max&eyes=variant09',
-  remainingVacationDays: 11,
-};
-
 export default class PersonalInfo {
-  constructor() {
-    this.ProfileInfo = new ProfileInfo({ user: dummyUserProfile });
+  constructor({ user }) {
+    this.ProfileInfo = new ProfileInfo({ user });
     this.WorkInfo = new WorkInfo();
   }
 

--- a/src/components/PersonalInfo/ProfileInfo.js
+++ b/src/components/PersonalInfo/ProfileInfo.js
@@ -18,7 +18,7 @@ export default class ProfileInfo {
         <div class="personal-profile">
           <div class="work-status-label${this.isWorking ? ' active' : ''}">${this.isWorking ? '근무중' : '근무전'}</div>
           <h2 class="profile-name">${this.user.name}</h2>
-          <span>${this.user.role}</span>
+          <span>${this.user.position}</span>
         </div>
       </div>
     `;

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -1,8 +1,35 @@
 import Main from '../../components/Main';
+import PersonalDetails from '../../components/PersonalInfo/PersonalDetails';
 import PersonalInfo from '../../components/PersonalInfo/PersonalInfo';
 import Title from '../../components/Title/Title';
 import { MENUS } from '../../utils/constants';
 import './Profile.css';
+
+const dummyUserProfile = {
+  employeeNumber: 101,
+  name: '안민지',
+  position: 'Software Engineer',
+  hireDate: '2015-10-11',
+  birthDate: '1987-05-08',
+  address: '경상북도 안산시 단원구 반포대거리',
+  email: 'anminji@cubeit.com',
+  phoneNumber: '010-7583-2446',
+  salary: 69000000,
+  isAdmin: true,
+  departmentNumber: 20,
+  education: '성균관대학교 소프트웨어공학 학사',
+  career: [
+    {
+      companyName: '카카오',
+      period: '2012-04-06 ~ 2014-07-02',
+      role: '백엔드 개발자',
+    },
+  ],
+  role: '백엔드 개발자',
+  profileImage:
+    'https://api.dicebear.com/9.x/lorelei/svg?seed=Max&eyes=variant09',
+  remainingVacationDays: 11,
+};
 
 export default class ProfilePage extends Main {
   constructor() {
@@ -11,13 +38,15 @@ export default class ProfilePage extends Main {
       title: MENUS.PROFILE,
       desktopOnly: true,
     });
-    this.PersonalInfo = new PersonalInfo();
+    this.PersonalInfo = new PersonalInfo({ user: dummyUserProfile });
+    this.PersonalDetails = new PersonalDetails({ user: dummyUserProfile });
   }
 
   render() {
     this.$container.innerHTML = `
       ${this.Title.html()}
       ${this.PersonalInfo.html()}
+      ${this.PersonalDetails.html()}
     `;
   }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

인사정보, 개인정보, 고용정보, 학력/경력 추가해서 프로필 페이지 퍼블리싱 끝냈습니다!

## 📋 작업 내용
- PersonalDetails 컴포넌트에서 관리자 / 본인 / 다른 직원일 때 각각 권한에 맞는 내용을 배열에 넣어줌
- PersonalDetail 컴포넌트에서 위의 배열을 받아 li 반환

## 🔧 변경 사항

- 더미데이터를 프로필 페이지 컴포넌트로 이동

## 📸 스크린샷 (선택 사항)

| Desktop  | Mobile |
| :--------: | :--: | 
| ![image](https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/cb9c71d0-1bdb-45e1-b026-ad647785610a) |  ![image](https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/0bb6b8a2-1d57-47e3-a6c7-5e8688be8169) |

## 📄 기타

현재 없는 데이터(추가 예정 데이터)는 옆에 `// 임시` 주석을 달아두었습니다!