### PR TITLE
[Feat] Table 컴포넌트 추가

### DIFF
--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -1,0 +1,82 @@
+.table-wrapper {
+  width: 100%;
+  min-width: 100vw;
+  overflow: hidden;
+}
+
+.table-container {
+  width: 100%;
+  border-top: 1px solid var(--color-light-gray);
+  border-bottom: 1px solid var(--color-light-gray);
+  overflow-x: auto;
+}
+
+.table-container table {
+  width: 100%;
+}
+
+.table-container thead {
+  height: 60px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-bottom: 1px solid var(--color-light-gray);
+  background-color: rgb(242 243 246 / 40%);
+}
+
+.table-container thead th {
+  color: var(--color-darkest-gray);
+}
+
+.table-container tr {
+  border-bottom: 1px solid var(--color-light-gray);
+}
+
+.table-container tr:last-child {
+  border-bottom: 0;
+}
+
+.table-container tbody {
+  background-color: #fff;
+}
+
+.table-container thead th,
+.table-container td {
+  min-width: 130px;
+  height: 60px;
+  padding: 0 20px;
+  line-height: 60px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.table-container td {
+  font-size: 0.875rem;
+  vertical-align: top;
+}
+
+.table-container td:has(img) {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+@media (width >= 1024px) {
+  .table-wrapper {
+    max-width: 1200px;
+    min-width: auto;
+    padding: 0 20px;
+    margin: 0 auto;
+  }
+
+  .table-container {
+    border: 1px solid var(--color-light-gray);
+    border-radius: 8px;
+  }
+
+  .table-container thead,
+  .table-container thead tr,
+  .table-container thead th {
+    height: 50px;
+    line-height: 50px;
+  }
+}

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,0 +1,33 @@
+import './Table.css';
+
+export default class Table {
+  constructor({ headers, contents }) {
+    this.headers = headers;
+    this.contents = contents;
+    this.width = Math.floor(100 / headers.length);
+  }
+
+  html() {
+    return `
+      <div class="table-wrapper">
+        <div class="table-container">
+          <table>
+            <thead>
+              <tr>
+                ${this.headers.map((header) => `<th style="width: ${this.width}%;">${header}</th>`).join('')}
+              </tr>
+            </thead>
+            <tbody>
+              ${this.contents
+                .map(
+                  (content) =>
+                    `<tr>${content.map((td) => `<td>${td}</td>`).join('')}</tr>`,
+                )
+                .join('')}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    `;
+  }
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

구성원 및 근무 관리에서 사용할 Table 컴포넌트를 추가했습니다.

## 📋 작업 내용

- Table 컴포넌트 추가
    - 각 열의 너비를 같은 비율로 맞춤
    - 모바일에서는 가로 스크롤이 생기도록 작업
- Table 전용 wrapper를 만들어 적용시킴 (공통 .wrapper와 달리 모바일에서 padding이 없어야해서)
- Avatar 컴포넌트를 사용하는 td(img를 포함한 td)에는 flex 속성을 걸어둠

## 📸 스크린샷 (선택 사항)

![image](https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/8f138327-d24a-4bd3-97ff-d48159c20735)