### PR TITLE
[Bug] 404 페이지 홈으로 이동 버튼 오류 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,17 @@
-import Layout from './components/Layout.js';
-import Header from './components/Header/Header.js';
-import NavBar from './components/NavBar/NavBar.js';
 import Route from './routes/Route.js';
+import { storeInstance } from './components/Store.js';
 
 class App {
   constructor() {
-    this.Layout = new Layout({ container: '#app' });
-    this.Header = new Header({ container: '.header-container' });
-    this.NavBar = new NavBar({ container: '.navbar' });
     this.Route = new Route();
+    this.Store = storeInstance;
+
+    this.init();
+  }
+
+  init() {
+    this.Store.renderLayout();
+    this.Route.init();
   }
 }
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,18 +1,18 @@
 import { logout } from '../API/AuthService.js';
 import Button from '../Button/Button.js';
+import Container from '../Container.js';
 import './Header.css';
 
-export default class Header {
-  constructor({ container, user }) {
-    this.$container = document.querySelector(container);
-    this.profileImage = user && user.profileImage;
-    this.userName = user && user.name;
+export default class Header extends Container {
+  constructor() {
+    super('.header-container');
+    // this.profileImage = user && user.profileImage;
+    // this.userName = user && user.name;
     this.Button = new Button({
       variant: 'tertiary',
       content: '로그아웃',
       size: 'small',
     });
-    this.render();
   }
 
   render() {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,7 +1,20 @@
-export default class Layout {
-  constructor({ container }) {
-    this.$container = document.querySelector(container);
-    this.render();
+import Container from './Container.js';
+import Header from './Header/Header.js';
+import NavBar from './NavBar/NavBar.js';
+
+export default class Layout extends Container {
+  constructor() {
+    super('#app');
+  }
+
+  renderHeader() {
+    this.Header = new Header();
+    this.Header.render();
+  }
+
+  renderNavbar() {
+    this.NavBar = new NavBar();
+    this.NavBar.render();
   }
 
   render() {
@@ -10,5 +23,8 @@ export default class Layout {
       <nav class="navbar"></nav>
       <main id="main" class="main-container"></main>
     `;
+
+    this.renderHeader();
+    this.renderNavbar();
   }
 }

--- a/src/components/NavBar/Menu.js
+++ b/src/components/NavBar/Menu.js
@@ -1,12 +1,25 @@
+import Container from '../Container.js';
 import Icon from '../Icon/Icon.js';
-import { COLORS, PATH } from '../../utils/constants.js';
+import { COLORS, PATH, PATH_TITLE } from '../../utils/constants.js';
+import {
+  clockIcon,
+  homeIcon,
+  membersIcon,
+  profileIcon,
+} from '../../utils/icons.js';
 
-export default class Menu {
-  constructor(container, menus) {
-    this.$container = document.querySelector(container);
+const menus = [
+  { path: PATH.HOME, title: PATH_TITLE.HOME, icon: homeIcon },
+  { path: PATH.MEMBERS, title: PATH_TITLE.MEMBERS, icon: membersIcon },
+  { path: PATH.PROFILE, title: PATH_TITLE.PROFILE, icon: profileIcon },
+  { path: PATH.WORK_MANAGE, title: PATH_TITLE.WORK_MANAGE, icon: clockIcon },
+];
+
+export default class Menu extends Container {
+  constructor() {
+    super('.menu-list');
     this.menus = menus;
     this._active = PATH.HOME;
-    this.render();
   }
 
   set active(activeMenu) {

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,10 +1,10 @@
 import logo from '../../../public/images/logo.svg';
+import Container from '../Container.js';
 import './NavBar.css';
 
-export default class NavBar {
-  constructor({ container }) {
-    this.$container = document.querySelector(container);
-    this.render();
+export default class NavBar extends Container {
+  constructor() {
+    super('.navbar');
   }
 
   render() {

--- a/src/components/SignInForm/SignInForm.css
+++ b/src/components/SignInForm/SignInForm.css
@@ -6,14 +6,10 @@
   display: block;
 }
 
-.button.btn-primary {
+.signin-form .button.btn-primary {
   margin-bottom: 15px;
 }
 
-.button.btn-primary:hover {
-  background-color: var(--color-primary);
-}
-
-.button.btn-primary:disabled:hover {
+.signin-form .button.btn-primary:disabled:hover {
   background-color: var(--color-lightest-gray);
 }

--- a/src/components/SignInForm/SignInForm.js
+++ b/src/components/SignInForm/SignInForm.js
@@ -84,7 +84,7 @@ export default class SignInForm {
 
   html() {
     return `
-      <form id="signin_form">
+      <form id="signin_form" class="signin-form">
         ${this.EmailInput.html()}
         ${this.PasswordInput.html()}
         <p class="alert-message"></p>

--- a/src/components/Store.js
+++ b/src/components/Store.js
@@ -1,7 +1,11 @@
+import Layout from './Layout.js';
+import Menu from './NavBar/Menu.js';
 import { fetchUser } from '../fetchData.js';
 
 class Store {
   constructor() {
+    this.Layout = new Layout();
+    this.Menu = null;
     this.user = null;
   }
 
@@ -10,6 +14,12 @@ class Store {
 
     this.user = await fetchUser();
     return this.user;
+  }
+
+  async renderLayout() {
+    this.Layout.render();
+    this.Menu = new Menu();
+    this.Menu.render();
   }
 }
 

--- a/src/pages/404/PageNotFound.css
+++ b/src/pages/404/PageNotFound.css
@@ -29,17 +29,9 @@
   font-size: 14px;
 }
 
-.not-found-container .home-link {
-  height: 50px;
-  padding: 0 40px;
+.not-found-container button {
   margin-top: 32px;
-  text-decoration: none;
-  text-align: center;
-  line-height: 50px;
-  color: #fff;
-  border-radius: 4px;
-  background-color: var(--color-primary);
-  transition: background 0.3s;
+  width: 140px;
 }
 
 /* desktop */
@@ -52,10 +44,6 @@
 
   .not-found-container .wrapper {
     padding-bottom: 50px;
-  }
-
-  .not-found-container .home-link:hover {
-    background-color: var(--color-primary-hover);
   }
 
   .not-found-image {

--- a/src/pages/404/PageNotFound.js
+++ b/src/pages/404/PageNotFound.js
@@ -1,11 +1,12 @@
-
 import Container from '../../components/Container.js';
 import notFoundImage from '../../../public/images/404.png';
 import './PageNotFound.css';
+import Button from '../../components/Button/Button.js';
 
 export default class PageNotFound extends Container {
   constructor() {
     super('#app');
+    this.homeButton = new Button({ content: '홈으로 이동' });
   }
 
   render() {
@@ -16,7 +17,7 @@ export default class PageNotFound extends Container {
           <h1 class="not-found-title">페이지를 찾을 수 없습니다</h1>
           <p>페이지가 존재하지 않거나, 사용할 수 없는 페이지입니다.</p>
           <p>입력하신 주소가 정확한지 다시 한 번 확인해주세요.</p>
-          <a class="home-link" href="/">홈으로 이동</a>
+          ${this.homeButton.html()}
         </div>
       </div>
     `;

--- a/src/pages/404/PageNotFound.js
+++ b/src/pages/404/PageNotFound.js
@@ -2,11 +2,22 @@ import Container from '../../components/Container.js';
 import notFoundImage from '../../../public/images/404.png';
 import './PageNotFound.css';
 import Button from '../../components/Button/Button.js';
+import { PATH } from '../../utils/constants.js';
 
 export default class PageNotFound extends Container {
   constructor() {
     super('#app');
+    this.path = PATH.HOME;
     this.homeButton = new Button({ content: '홈으로 이동' });
+  }
+
+  onClickHomeButton = () => {
+    window.location.href = this.path;
+  };
+
+  setEventListener() {
+    const $button = document.querySelector('.not-found-container button');
+    $button.addEventListener('click', this.onClickHomeButton);
   }
 
   render() {
@@ -21,5 +32,7 @@ export default class PageNotFound extends Container {
         </div>
       </div>
     `;
+
+    this.setEventListener();
   }
 }

--- a/src/routes/Route.js
+++ b/src/routes/Route.js
@@ -1,5 +1,5 @@
 import { isLoggedIn } from '../components/API/AuthService.js';
-import Menu from '../components/NavBar/Menu.js';
+import { storeInstance } from '../components/Store.js';
 import {
   HomePage,
   MembersPage,
@@ -9,29 +9,13 @@ import {
   PageNotFound,
 } from '../pages/index.js';
 import { PATH_TITLE, PATH } from '../utils/constants.js';
-import {
-  clockIcon,
-  homeIcon,
-  membersIcon,
-  profileIcon,
-} from '../utils/icons.js';
 import { matchRoute } from '../utils/matchRoute.js';
-
-const menus = [
-  { path: PATH.HOME, title: PATH_TITLE.HOME, icon: homeIcon },
-  { path: PATH.MEMBERS, title: PATH_TITLE.MEMBERS, icon: membersIcon },
-  { path: PATH.PROFILE, title: PATH_TITLE.PROFILE, icon: profileIcon },
-  { path: PATH.WORK_MANAGE, title: PATH_TITLE.WORK_MANAGE, icon: clockIcon },
-];
 
 export default class Route {
   constructor() {
     this.notFoundPage = new PageNotFound();
-    this.Menu = new Menu('.menu-list', menus);
     this.title = 'CubeIT ';
     this.currentPage = null;
-
-    this.init();
   }
 
   setRoutes() {
@@ -95,6 +79,7 @@ export default class Route {
   init() {
     window.addEventListener('popstate', () => this.route());
     document.body.addEventListener('click', this.handleNavigatePage);
+    this.Menu = storeInstance.Menu;
     this.setRoutes();
     this.route();
   }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

404 페이지에서 홈으로 이동 버튼을 누르면 홈페이지가 렌더링되지 않는 이슈를 해결했습니다.

## 📋 작업 내용

- 404 페이지에서 홈으로 이동 버튼을 누르면 홈페이지로 새로고침
- Layout 컴포넌트를 Store에서 관리할 수 있도록 

## 🔧 변경 사항

- Button hover 스타일 오류 수정 (SignInForm.css에서 덮어쓰고 있는 css 코드가 있어 명시도를 높여줌)
- Layout 컴포넌트를 Store에서 관리
   - 레이아웃 관련 컴포넌트들 Container를 상속받도록 수정
   - 컴포넌트 내에서 `this.render`를 하지 않고 인스턴스를 생성하는 컴포넌트에서 `render` 함수 호출

## 📄 기타

- 로그인 페이지와 404 페이지 모두 `#app` 컨테이너에 innerHTML으로 렌더링하고 있는데, 로그인 했을때는 정상적으로 Home이 나오지만 404 페이지는 Home이 나오지 않아서 로그인 페이지와 같은 방식으로 해결했습니다.
- 로그인 페이지와 같은 방법을 쓰면 Home 페이지가 잘 나오는 대신 새로고침이 발생합니다..!
   - 이를 해결해보고자.. Layout 컴포넌트를 Store에서 공통으로 관리하고, 버튼 클릭 시 레이아웃을 재랜더링한 후 popstate를 발생시키는 방식으로 시도해봤는데 실패...... 그래서 일단 Store에서 관리하는 부분만 넣어뒀습니다.. 
