### PR TITLE
[Feat] 프로필 페이지의 더미 데이터를 실제 데이터로 변경

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import db from './database.js';
 import { verifyPassword } from './passwords.js';
+import { extractEmployeeNumber } from './middlewares/authMiddleware.js';
 
 dotenv.config();
 
@@ -177,28 +178,8 @@ app.get('/api/member/:employeeNumber', (req, res) => {
 });
 
 // eslint-disable-next-line consistent-return
-app.get('/api/user', (req, res) => {
-  const authHeader = req.headers.authorization;
-  const token = authHeader && authHeader.split(' ')[1];
-
-  if (!token) {
-    return res.status(401).json({
-      status: 'Error',
-      error: '토큰이 없습니다.',
-    });
-  }
-
-  let employeeNumber;
-
-  try {
-    const decoded = jwt.verify(token, SECRET_KEY);
-    employeeNumber = decoded.id;
-  } catch (err) {
-    return res.status(403).json({
-      status: 'Error',
-      error: '사원 정보가 없습니다.',
-    });
-  }
+app.get('/api/user', extractEmployeeNumber, (req, res) => {
+  const { employeeNumber } = req;
 
   const sql = `
     SELECT 

--- a/server/index.js
+++ b/server/index.js
@@ -178,12 +178,25 @@ app.get('/api/member/:employeeNumber', (req, res) => {
 
 // eslint-disable-next-line consistent-return
 app.get('/api/user', (req, res) => {
-  const { employeeNumber } = req.query;
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.split(' ')[1];
 
-  if (!employeeNumber) {
-    return res.status(422).json({
+  if (!token) {
+    return res.status(401).json({
       status: 'Error',
-      error: '사원 번호가 누락되었습니다.',
+      error: '토큰이 없습니다.',
+    });
+  }
+
+  let employeeNumber;
+
+  try {
+    const decoded = jwt.verify(token, SECRET_KEY);
+    employeeNumber = decoded.id;
+  } catch (err) {
+    return res.status(403).json({
+      status: 'Error',
+      error: '사원 정보가 없습니다.',
     });
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -229,6 +229,42 @@ app.get('/api/user', extractEmployeeNumber, (req, res) => {
 });
 
 // eslint-disable-next-line consistent-return
+app.get('/api/attendance/weekly', extractEmployeeNumber, (req, res) => {
+  const { employeeNumber } = req;
+
+  const today = new Date();
+  const dayOfWeek = today.getDay();
+  const diffToMonday = (dayOfWeek + 6) % 7;
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - diffToMonday);
+  const mondayStr = monday.toISOString().split('T')[0];
+  const todayStr = today.toISOString().split('T')[0];
+
+  const sql = `
+    SELECT * 
+    FROM 
+      Attendance 
+    WHERE 
+      employeeNumber = ? AND date BETWEEN ? AND ?
+    ORDER BY date DESC`;
+
+  // eslint-disable-next-line consistent-return
+  db.all(sql, [employeeNumber, mondayStr, todayStr], (err, rows) => {
+    if (err) {
+      return res.status(500).json({
+        status: 'Error',
+        error: err.message,
+      });
+    }
+
+    res.json({
+      status: 'OK',
+      data: rows,
+    });
+  });
+});
+
+// eslint-disable-next-line consistent-return
 app.get('/api/attendance/:page', (req, res) => {
   let { page } = req.params;
   const { employeeNumber, max = 10 } = req.query;

--- a/server/middlewares/authMiddleware.js
+++ b/server/middlewares/authMiddleware.js
@@ -1,0 +1,30 @@
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+
+dotenv.config();
+
+const SECRET_KEY = process.env.JWT_SECRET;
+
+// eslint-disable-next-line consistent-return
+export const extractEmployeeNumber = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) {
+    return res.status(401).json({
+      status: 'Error',
+      error: '토큰이 없습니다.',
+    });
+  }
+
+  try {
+    const decoded = jwt.verify(token, SECRET_KEY);
+    req.employeeNumber = decoded.id;
+    next();
+  } catch (err) {
+    return res.status(403).json({
+      status: 'Error',
+      error: '사원 정보가 없습니다.',
+    });
+  }
+};

--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { API_BASE_URL } from './config.js';
+import { handleAPIError } from './errorHandling.js';
+
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export async function apiCall({
+  endpoint,
+  method = 'get',
+  params = {},
+  data = null,
+  auth = false,
+}) {
+  try {
+    const config = {
+      url: endpoint,
+      method,
+      params,
+      data,
+    };
+
+    if (auth) {
+      const token = localStorage.getItem('token');
+      if (token) {
+        config.headers = {
+          ...config.headers,
+          Authorization: `Bearer ${token}`,
+        };
+      }
+    }
+
+    const response = await apiClient(config);
+    return response.data;
+  } catch (error) {
+    const apiError = handleAPIError(error);
+    throw apiError;
+  }
+}
+
+export default apiClient;

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,0 +1,26 @@
+const { VITE_SERVER_URL } = import.meta.env;
+
+if (!VITE_SERVER_URL) {
+  console.log(
+    'server url이 존재하지 않습니다. 기본 url(localhost:8080)을 사용합니다.',
+  );
+}
+
+export const API_BASE_URL = VITE_SERVER_URL || 'http://localhost:8080';
+
+const apiUrl = (path) => {
+  const baseUrl = API_BASE_URL.endsWith('/')
+    ? API_BASE_URL.slice(0, -1)
+    : API_BASE_URL;
+  return `${baseUrl}/${path.startsWith('/') ? path.slice(1) : path}`;
+};
+
+export const API_ENDPOINTS = {
+  MEMBERS: apiUrl('api/members'),
+  MEMBER: apiUrl('api/member'),
+  ATTENDANCE: apiUrl('api/attendance'),
+  VACATION_REQUESTS: apiUrl('api/vacationRequests'),
+  DEPARTMENTS: apiUrl('api/departments'),
+  ANNOUNCEMENTS: apiUrl('api/announcements'),
+  USER: apiUrl('api/user'),
+};

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -19,6 +19,7 @@ export const API_ENDPOINTS = {
   MEMBERS: apiUrl('api/members'),
   MEMBER: apiUrl('api/member'),
   ATTENDANCE: apiUrl('api/attendance'),
+  ATTENDANCE_WEEKLY: apiUrl('api/attendance/weekly'),
   VACATION_REQUESTS: apiUrl('api/vacationRequests'),
   DEPARTMENTS: apiUrl('api/departments'),
   ANNOUNCEMENTS: apiUrl('api/announcements'),

--- a/src/api/endpoints/user.js
+++ b/src/api/endpoints/user.js
@@ -14,3 +14,17 @@ export async function fetchUser() {
     throw error;
   }
 }
+
+export async function fetchWeeklyAttendances() {
+  try {
+    const response = await apiCall({
+      endpoint: API_ENDPOINTS.ATTENDANCE_WEEKLY,
+      method: 'get',
+      auth: true,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch user weekly attendances:', error);
+    throw error;
+  }
+}

--- a/src/api/endpoints/user.js
+++ b/src/api/endpoints/user.js
@@ -1,0 +1,16 @@
+import { apiCall } from '../apiClient.js';
+import { API_ENDPOINTS } from '../config.js';
+
+export async function fetchUser() {
+  try {
+    const response = await apiCall({
+      endpoint: API_ENDPOINTS.USER,
+      method: 'get',
+      auth: true,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch user:', error);
+    throw error;
+  }
+}

--- a/src/api/errorHandling.js
+++ b/src/api/errorHandling.js
@@ -1,0 +1,23 @@
+export class APIError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.name = 'APIError';
+    this.status = status;
+  }
+}
+
+export function handleAPIError(error) {
+  if (error.response) {
+    // 서버가 2xx 범위를 벗어나는 상태 코드로 응답한 경우
+    throw new APIError(
+      error.response.data.message || '서버 에러가 발생했습니다.',
+      error.response.status,
+    );
+  } else if (error.request) {
+    // 요청이 이루어졌으나 응답을 받지 못한 경우
+    throw new APIError('서버로부터 응답을 받지 못했습니다.', 0);
+  } else {
+    // 요청 설정 중에 오류가 발생한 경우
+    throw new APIError('요청 설정 중 오류가 발생했습니다.', 0);
+  }
+}

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -11,7 +11,7 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 120%;
+  width: 110%;
   transform: translate(-50%, -50%);
 }
 

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -26,6 +26,7 @@
 .btn-secondary:disabled {
   background-color: var(--color-lightest-gray);
   color: var(--color-dark-gray);
+  cursor: default;
 }
 
 .btn-tertiary {
@@ -36,6 +37,7 @@
 .btn-tertiary:disabled {
   background-color: var(--color-lightest-gray);
   color: var(--color-dark-gray);
+  cursor: default;
 }
 
 .btn-ghost {
@@ -74,5 +76,9 @@
   .btn-text:hover {
     background-color: var(--color-lightest-gray);
     color: var(--color-black);
+  }
+
+  .btn-secondary:disabled:hover {
+    background-color: var(--color-lightest-gray);
   }
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -17,21 +17,6 @@
     height: 100%;
   }
 
-  .header-profile {
-    position: relative;
-    width: 36px;
-    height: 36px;
-    border: 1px solid var(--color-light-gray);
-    border-radius: 4px;
-    overflow: hidden;
-  }
-
-  .header-profile-image {
-    position: absolute;
-    left: -2px;
-    width: 40px;
-  }
-
   .logout-btn-wrapper button {
     margin-left: 5px;
     padding: 5px;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,13 +1,14 @@
 import { logout } from '../API/AuthService.js';
+import Avatar from '../Avatar/Avatar.js';
 import Button from '../Button/Button.js';
 import Container from '../Container.js';
+import { storeInstance } from '../Store.js';
 import './Header.css';
 
 export default class Header extends Container {
   constructor() {
     super('.header-container');
-    // this.profileImage = user && user.profileImage;
-    // this.userName = user && user.name;
+    this.store = storeInstance;
     this.Button = new Button({
       variant: 'tertiary',
       content: '로그아웃',
@@ -15,16 +16,22 @@ export default class Header extends Container {
     });
   }
 
+  async renderAvatar() {
+    if (!this.user) {
+      this.user = await this.store.getUser();
+      this.Avatar = new Avatar({
+        url: this.user.profileImage,
+      });
+    }
+
+    const $avatarContainer = document.querySelector('header .avatar-container');
+    $avatarContainer.innerHTML = this.Avatar.html();
+  }
+
   render() {
     this.$container.innerHTML = `
       <div class="wrapper">
-        <div class="header-profile">
-          <img
-            class="header-profile-image"
-            src="${this.profileImage || 'https://api.dicebear.com/9.x/lorelei/svg?seed=Max&eyes=variant09'}"
-            alt="${this.userName || '김직원'}"
-          />
-        </div>
+        <div class="avatar-container"></div>
         <div class ='logout-btn-wrapper'>
           ${this.Button.html()}
         </div>
@@ -33,5 +40,7 @@ export default class Header extends Container {
     document
       .querySelector('.logout-btn-wrapper button')
       .addEventListener('click', logout);
+
+    this.renderAvatar();
   }
 }

--- a/src/components/PersonalInfo/CurrentTime.js
+++ b/src/components/PersonalInfo/CurrentTime.js
@@ -1,0 +1,52 @@
+import dayjs from 'dayjs';
+
+export default class CurrentTime {
+  constructor() {
+    this.$time = document.querySelector('.work-hour-time.current');
+    this.timeout = null;
+    this.timer = null;
+  }
+
+  updateTime() {
+    const currentTime = dayjs().format('HH:mm');
+
+    this.$time.setAttribute('datetime', currentTime);
+    this.$time.innerText = currentTime;
+  }
+
+  getNextUpdateDelay() {
+    const now = dayjs();
+    const nextMinuteStart = now.add(1, 'minute').startOf('minute');
+    const delay = nextMinuteStart.diff(now);
+
+    return delay;
+  }
+
+  cleanUp() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
+    }
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  render() {
+    this.updateTime();
+
+    if (!this.timer) {
+      const delay = this.getNextUpdateDelay();
+
+      const updateNextTime = () => {
+        this.updateTime();
+        const nextDelay = this.getNextUpdateDelay();
+        this.timer = setTimeout(updateNextTime, nextDelay);
+      };
+
+      this.timeout = setTimeout(updateNextTime, delay);
+    }
+  }
+}

--- a/src/components/PersonalInfo/PersonalDetails.js
+++ b/src/components/PersonalInfo/PersonalDetails.js
@@ -15,35 +15,35 @@ export default class PersonalDetails {
 
   setInfoArray() {
     this.personalInfo = [
-      { subtitle: '조직', contents: this.user.departmentName },
-      { subtitle: '직책', contents: this.user.role },
+      { subtitle: '조직', contents: this.member.departmentName },
+      { subtitle: '직책', contents: this.member.role },
     ];
 
     this.privateInfo = [
-      { subtitle: '이메일', contents: this.user.email },
-      { subtitle: '전화번호', contents: this.user.phoneNumber },
+      { subtitle: '이메일', contents: this.member.email },
+      { subtitle: '전화번호', contents: this.member.phoneNumber },
     ];
 
     if (this.isAdmin || this.isOwner) {
       this.privateInfo.unshift({
         subtitle: '생년월일',
-        contents: this.user.birthDate,
+        contents: this.member.birthDate,
       });
 
       this.privateInfo.push({
         subtitle: '자택 주소',
-        contents: this.user.address,
+        contents: this.member.address,
       });
 
       this.employmentInfo = [
-        { subtitle: '입사일', contents: this.user.hireDate },
-        { subtitle: '근무유형', contents: this.user.employmentType },
+        { subtitle: '입사일', contents: this.member.hireDate },
+        { subtitle: '근무유형', contents: this.member.employmentType },
       ];
 
-      const careers = JSON.parse(this.user.career);
+      const careers = JSON.parse(this.member.career);
       careers.sort(sortByPeriod);
       this.educationAndCareerInfo = [
-        { subtitle: '학력', contents: this.user.education },
+        { subtitle: '학력', contents: this.member.education },
         {
           subtitle: '경력',
           contents: `<ul class="career-list">
@@ -67,10 +67,10 @@ export default class PersonalDetails {
       ];
     }
 
-    if (this.isAdmin && this.user.salary) {
+    if (this.isAdmin && this.member.salary) {
       this.employmentInfo.push({
         subtitle: '연봉',
-        contents: this.user.salary.toLocaleString('en-US'),
+        contents: this.member.salary.toLocaleString('en-US'),
       });
     }
   }
@@ -85,13 +85,13 @@ export default class PersonalDetails {
     `;
   }
 
-  async render() {
-    if (!this.user) {
-      this.user = await this.store.getUser();
-      this.isAdmin = this.user.isAdmin;
-      this.setInfoArray();
-    }
+  async render(member) {
+    this.user = await this.store.getUser();
+    this.member = member;
+    this.isAdmin = !!this.member.isAdmin;
+    this.isOwner = this.member.employeeNumber === this.user.employeeNumber;
 
+    this.setInfoArray();
     this.renderPersonalDetails();
   }
 

--- a/src/components/PersonalInfo/PersonalInfo.js
+++ b/src/components/PersonalInfo/PersonalInfo.js
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-
 import ProfileInfo from './ProfileInfo.js';
 import WorkInfo from './WorkInfo.js';
 import './PersonalInfo.css';
@@ -8,22 +6,6 @@ export default class PersonalInfo {
   constructor() {
     this.ProfileInfo = new ProfileInfo();
     this.WorkInfo = new WorkInfo();
-  }
-
-  updateTime() {
-    const currentTime = dayjs().format('HH:mm');
-
-    const $time = document.querySelector('.work-hour-time.current');
-    $time.setAttribute('datetime', currentTime);
-    $time.innerText = currentTime;
-  }
-
-  getNextUpdateDelay() {
-    const now = dayjs();
-    const nextMinuteStart = now.add(1, 'minute').startOf('minute');
-    const delay = nextMinuteStart.diff(now);
-
-    return delay;
   }
 
   render() {

--- a/src/components/PersonalInfo/PersonalInfo.js
+++ b/src/components/PersonalInfo/PersonalInfo.js
@@ -13,7 +13,7 @@ export default class PersonalInfo {
   updateTime() {
     const currentTime = dayjs().format('HH:mm');
 
-    const $time = document.querySelector('.work-hour-time');
+    const $time = document.querySelector('.work-hour-time.current');
     $time.setAttribute('datetime', currentTime);
     $time.innerText = currentTime;
   }
@@ -28,6 +28,7 @@ export default class PersonalInfo {
 
   render() {
     this.ProfileInfo.render();
+    this.WorkInfo.render();
   }
 
   html() {

--- a/src/components/PersonalInfo/ProfileInfo.js
+++ b/src/components/PersonalInfo/ProfileInfo.js
@@ -1,11 +1,22 @@
 import Avatar from '../Avatar/Avatar.js';
 import './ProfileInfo.css';
 import { storeInstance } from '../Store.js';
+import { setTodayWork } from '../../utils/userWork.js';
 
 export default class ProfileInfo {
   constructor() {
     this.store = storeInstance;
-    this.isWorking = false; // 임시
+  }
+
+  renderLabel() {
+    const $label = document.querySelector('.work-status-label');
+    if (this.isWorking) {
+      $label.classList.add('active');
+      $label.innerText = '근무중';
+    } else {
+      $label.classList.remove('active');
+      $label.innerText = '근무전';
+    }
   }
 
   renderAvatar() {
@@ -34,6 +45,19 @@ export default class ProfileInfo {
         size: 'large',
       });
     }
+
+    if (!this.isWorking) {
+      const weeklyAttendances = await this.store.getWeeklyAttendances();
+      const today = new Date().toISOString().split('T')[0];
+      const { startTime, endTime } =
+        weeklyAttendances.filter(
+          (attendance) => attendance.date === today,
+        )[0] || setTodayWork(today);
+
+      this.isWorking = !!(startTime && !endTime);
+    }
+
+    this.renderLabel();
     this.renderAvatar();
     this.renderUserInfo();
   }
@@ -43,7 +67,7 @@ export default class ProfileInfo {
       <div class="profile-info">
         <div class="avatar-container"></div>
         <div class="personal-profile">
-          <div class="work-status-label${this.isWorking ? ' active' : ''}">${this.isWorking ? '근무중' : '근무전'}</div>
+          <div class="work-status-label"></div>
           <h2 class="profile-name"></h2>
           <span class="profile-position"></span>
         </div>

--- a/src/components/PersonalInfo/WorkInfo.js
+++ b/src/components/PersonalInfo/WorkInfo.js
@@ -1,6 +1,7 @@
 import Button from '../Button/Button.js';
 import Icon from '../Icon/Icon.js';
 import ProgressRing from '../ProgressRing.js/ProgressRing.js';
+import CurrentTime from './CurrentTime.js';
 import { COLORS } from '../../utils/constants.js';
 import { clockIcon } from '../../utils/icons.js';
 import './WorkInfo.css';
@@ -55,8 +56,14 @@ export default class WorkInfo {
     const $endTime = document.querySelector('.work-hour-time.end');
 
     $buttonContainer.innerHTML = this.Button.html();
-    $startTime.innerText = startTime;
-    $endTime.innerText = endTime;
+
+    this.CurrentTime = new CurrentTime();
+    this.CurrentTime.cleanUp();
+    this.CurrentTime.render();
+    $startTime.innerText = startTime || '-';
+    $startTime.setAttribute('datetime', startTime);
+    $endTime.innerText = endTime || '-';
+    $endTime.setAttribute('datetime', endTime);
   }
 
   async render() {

--- a/src/components/PersonalInfo/WorkInfo.js
+++ b/src/components/PersonalInfo/WorkInfo.js
@@ -4,49 +4,96 @@ import ProgressRing from '../ProgressRing.js/ProgressRing.js';
 import { COLORS } from '../../utils/constants.js';
 import { clockIcon } from '../../utils/icons.js';
 import './WorkInfo.css';
+import { storeInstance } from '../Store.js';
+import {
+  calculateWeeklyWorkHours,
+  setTodayWork,
+} from '../../utils/userWork.js';
 
 export default class WorkInfo {
   constructor() {
-    this.weeklyWorkHours = 32;
+    this.store = storeInstance;
+    this.weeklyAttendances = null;
+    this.weeklyWorkHours = null;
     this.Icon = new Icon({
       svg: clockIcon,
       options: { color: COLORS.DARK_GRAY },
     });
-    this.ProgressRing = new ProgressRing({ percent: 50 });
+  }
+
+  renderWeeklyWorkHours() {
+    const $time = document.querySelector('.weekly-work-hours-time');
+    $time.innerHTML = `${this.weeklyWorkHours}시간`;
+  }
+
+  renderProgressRing() {
+    const $container = document.querySelector('.progress-ring-container');
+    const percent = (this.weeklyWorkHours / 40) * 100;
+    this.ProgressRing = new ProgressRing({ percent });
+    this.Button = null;
+    $container.innerHTML = this.ProgressRing.html();
+  }
+
+  renderDailyWork() {
+    const today = new Date().toISOString().split('T')[0];
+    const { startTime, endTime } =
+      this.weeklyAttendances.filter(
+        (attendance) => attendance.date === today,
+      )[0] || setTodayWork(today);
+
     this.Button = new Button({
-      variant: 'secondary',
+      variant: startTime && !endTime ? 'primary' : 'secondary',
       size: 'large',
-      content: '근무 시작',
+      content: startTime && !endTime ? '근무 종료' : '근무 시작',
+      disabled: !!endTime,
     });
+
+    const $buttonContainer = document.querySelector(
+      '.work-hours-button-container',
+    );
+    const $startTime = document.querySelector('.work-hour-time.start');
+    const $endTime = document.querySelector('.work-hour-time.end');
+
+    $buttonContainer.innerHTML = this.Button.html();
+    $startTime.innerText = startTime;
+    $endTime.innerText = endTime;
+  }
+
+  async render() {
+    if (!this.weeklyAttendances) {
+      this.weeklyAttendances = await this.store.getWeeklyAttendances();
+      this.weeklyWorkHours = calculateWeeklyWorkHours(this.weeklyAttendances);
+    }
+    this.renderWeeklyWorkHours();
+    this.renderProgressRing();
+    this.renderDailyWork();
   }
 
   html() {
-    return `
+    return /* HTML */ `
       <div class="work-info-container">
         <div class="work-info weekly-work-hours">
           ${this.Icon.html()}
           <div class="weekly-work-hours-title">이번 주 근무 시간</div>
-          <strong class="weekly-work-hours-time">${this.weeklyWorkHours}시간</strong>
-          ${this.ProgressRing.html()}
+          <strong class="weekly-work-hours-time"></strong>
+          <div class="progress-ring-container"></div>
         </div>
         <div class="work-info daily-work-hours">
           <ul class="work-hours-list">
             <li>
               <div class="work-hour-title">현재 시각</div>
-              <time class="work-hour-time" datetime="07:06">07:06</time>
+              <time class="work-hour-time current" datetime=""></time>
             </li>
             <li>
               <div class="work-hour-title">근무 시작</div>
-              <time class="work-hour-time" datetime="">-</time>
+              <time class="work-hour-time start" datetime="">-</time>
             </li>
             <li>
               <div class="work-hour-title">근무 종료</div>
-              <time class="work-hour-time" datetime="">-</time>
+              <time class="work-hour-time end" datetime="">-</time>
             </li>
           </ul>
-          <div class="work-hours-button-container" type="button">
-            ${this.Button.html()}
-          </div>
+          <div class="work-hours-button-container" type="button"></div>
         </div>
       </div>
     `;

--- a/src/components/Store.js
+++ b/src/components/Store.js
@@ -1,12 +1,13 @@
 import Layout from './Layout.js';
 import Menu from './NavBar/Menu.js';
-import { fetchUser } from '../api/endpoints/user.js';
+import { fetchUser, fetchWeeklyAttendances } from '../api/endpoints/user.js';
 
 class Store {
   constructor() {
     this.Layout = new Layout();
     this.Menu = null;
     this.user = null;
+    this.weeklyAttendances = null;
   }
 
   async getUser() {
@@ -14,6 +15,13 @@ class Store {
 
     this.user = await fetchUser();
     return this.user;
+  }
+
+  async getWeeklyAttendances() {
+    if (this.weeklyAttendances) return this.weeklyAttendances;
+
+    this.weeklyAttendances = await fetchWeeklyAttendances();
+    return this.weeklyAttendances;
   }
 
   async renderLayout() {

--- a/src/components/Store.js
+++ b/src/components/Store.js
@@ -1,6 +1,6 @@
 import Layout from './Layout.js';
 import Menu from './NavBar/Menu.js';
-import { fetchUser } from '../fetchData.js';
+import { fetchUser } from '../api/endpoints/user.js';
 
 class Store {
   constructor() {

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -3,6 +3,7 @@ import Button from '../../components/Button/Button.js';
 import Container from '../../components/Container.js';
 import PersonalDetails from '../../components/PersonalInfo/PersonalDetails.js';
 import PersonalInfo from '../../components/PersonalInfo/PersonalInfo.js';
+import { storeInstance } from '../../components/Store.js';
 import Title from '../../components/Title/Title.js';
 import { PATH_TITLE } from '../../utils/constants.js';
 import './Profile.css';
@@ -10,6 +11,7 @@ import './Profile.css';
 export default class ProfilePage extends Container {
   constructor() {
     super('#main');
+    this.store = storeInstance;
     this.Title = new Title({
       title: PATH_TITLE.PROFILE,
       desktopOnly: true,
@@ -22,6 +24,13 @@ export default class ProfilePage extends Container {
       variant: 'tertiary',
       content: '로그아웃',
     });
+  }
+
+  async renderPersonalDetails() {
+    if (!this.user) {
+      this.user = await this.store.getUser();
+    }
+    this.PersonalDetails.render(this.user);
   }
 
   renderCurrentTime() {
@@ -64,7 +73,7 @@ export default class ProfilePage extends Container {
 
     this.renderCurrentTime();
     this.PersonalInfo.render();
-    this.PersonalDetails.render();
+    this.renderPersonalDetails();
     document
       .querySelector('.logout-btn-wrapper-inprofile button')
       .addEventListener('click', logout);

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -18,8 +18,6 @@ export default class ProfilePage extends Container {
     });
     this.PersonalInfo = new PersonalInfo();
     this.PersonalDetails = new PersonalDetails();
-    this.timeout = null;
-    this.timer = null;
     this.Button = new Button({
       variant: 'tertiary',
       content: '로그아웃',
@@ -33,34 +31,6 @@ export default class ProfilePage extends Container {
     this.PersonalDetails.render(this.user);
   }
 
-  renderCurrentTime() {
-    this.PersonalInfo.updateTime();
-
-    if (!this.timer) {
-      const delay = this.PersonalInfo.getNextUpdateDelay();
-
-      const updateNextTime = () => {
-        this.PersonalInfo.updateTime();
-        const nextDelay = this.PersonalInfo.getNextUpdateDelay();
-        this.timer = setTimeout(updateNextTime, nextDelay);
-      };
-
-      this.timeout = setTimeout(updateNextTime, delay);
-    }
-  }
-
-  cleanUp() {
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-      this.timeout = null;
-    }
-
-    if (this.timer) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
-  }
-
   render() {
     this.$container.innerHTML = `
       ${this.Title.html()}
@@ -71,7 +41,6 @@ export default class ProfilePage extends Container {
       </div>
     `;
 
-    this.renderCurrentTime();
     this.PersonalInfo.render();
     this.renderPersonalDetails();
     document

--- a/src/utils/userWork.js
+++ b/src/utils/userWork.js
@@ -1,0 +1,28 @@
+function getTimeInMinutes(time) {
+  const [hours, minutes, seconds] = time.split(':').map(Number);
+  return hours * 60 + minutes + seconds / 60;
+}
+
+function getWorkDuration({ startTime, endTime }) {
+  const MAX = 9;
+  const startMinutes = getTimeInMinutes(startTime);
+  const endMinutes = getTimeInMinutes(endTime);
+  const durationHours = (endMinutes - startMinutes) / 60;
+
+  return durationHours === MAX ? durationHours - 1 : durationHours;
+}
+
+function calculateWeeklyWorkHours(data) {
+  return data.reduce((total, current) => total + getWorkDuration(current), 0);
+}
+
+function setTodayWork(today) {
+  return {
+    date: today,
+    startTime: null,
+    endTime: null,
+    status: null,
+  };
+}
+
+export { calculateWeeklyWorkHours, setTodayWork };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

프로필 페이지의 더미 데이터를 실제 데이터로 변경했습니다.

## 📋 작업 내용

- API 관련 코드 재사용성을 위한 apiClient, errorHandling, config 파일 추가
- 프로필 페이지 더미 데이터 실제 데이터로 변경
- 홈페이지에서도 PersonalInfo 컴포넌트가 프로필 페이지와 똑같이 보이도록 수정
- Header 컴포넌트 실제 유저 아바타로 수정
- PersonalDetails 컴포넌트 재사용하기 편하게 수정

## 🔧 변경 사항

- 토큰으로 로그인한 유저의 사원 번호를 알아내는 미들웨어 추가

## 📸 스크린샷 (선택 사항)

<img width="1341" alt="image" src="https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/589d92d0-561a-4b28-bb78-7e8f106d8e97">

## 📄 기타

- attendance.json 파일을 임의 수정 후 작업했습니다!
