### PR TITLE
[feat] 홈페이지 주요사항을 실제데이터로 변경

### DIFF
--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -107,11 +107,17 @@
   gap: 12px;
 }
 
+.announcement-item {
+}
+
 .announcement-content {
-  display: flex;
-  align-items: center;
-  margin-bottom: 25px;
-  margin-left: 15px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 0;
+  padding-right: 0;
+  color: var(--color-darkest-gray);
 }
 
 .announcement-author .author-image-container .profile-img-container {
@@ -128,12 +134,6 @@
 .announcement-info .announcement-time {
   font-size: 14px;
   color: var(--color-dark-gray);
-}
-
-.announcement-contents {
-  padding: 12px 0 20px;
-  font-size: 14px;
-  line-height: 1.6;
 }
 
 /* tablet */
@@ -163,7 +163,7 @@
   }
 
   .home-container .gallery {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
   }
 
   .home-container .gallery-image-box {

--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -107,16 +107,11 @@
   gap: 12px;
 }
 
-.announcement-item {
-}
-
 .announcement-content {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  margin-left: 0;
-  margin-right: 0;
-  padding-left: 0;
-  padding-right: 0;
+  margin-top: 20px;
+  margin-bottom: 25px;
+  margin-left: 15px;
+  padding-bottom: 60px;
   color: var(--color-darkest-gray);
 }
 

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -175,8 +175,3 @@ export default class HomePage extends Container {
     });
   }
 }
-
-document.addEventListener('DOMContentLoaded', () => {
-  const homePageInstance = new HomePage();
-  homePageInstance.render();
-});

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -104,21 +104,13 @@ export default class HomePage extends Container {
                 }).html()}
               </div>
               <div class="announcement-info">
-                <div class="announcement-author-name">안민지</div>
+                <div class="announcement-author-name">
+                  ${dummyUserProfile.name}
+                </div>
                 <div class="announcement-time">약 15시간 전</div>
               </div>
             </div>
-            <div class="announcement-contents">
-              <p>
-                오늘은 즐거운 월급날입니다. 오늘은 즐거운 월급날입니다. 오늘은
-                즐거운 월급날입니다. 오늘은 즐거운 월급날입니다. <br />오늘은
-                즐거운 월급날입니다. 오늘은 즐거운 월급날입니다. 오늘은 즐거운
-                월급날입니다. <br />
-                오늘은 즐거운 월급날입니다. 오늘은 즐거운 월급날입니다. 오늘은
-                즐거운 월급날입니다. 오늘은 즐거운 월급날입니다. 오늘은 즐거운
-                월급날입니다.
-              </p>
-            </div>
+            <div class="announcement-content"></div>
           </div>
         </section>
       </div>
@@ -130,6 +122,8 @@ export default class HomePage extends Container {
       const announcements = response.data.data; // 데이터 추출
 
       this.renderAnnouncements(announcements);
+      // 추가적인 공지사항 불러오기
+      this.renderAdditionalAnnouncement();
     } catch (error) {
       console.error('공지사항 데이터를 가져오는 중 에러 발생:', error);
     }
@@ -158,5 +152,38 @@ export default class HomePage extends Container {
         galleryElement.appendChild(announcementElement);
       }
     });
+  }
+
+  async renderAdditionalAnnouncement() {
+    try {
+      const response = await axios.get('/api/announcements/6'); // announcementId가 6인 공지사항을 가져옵니다.
+      const announcement = response.data.data; // 데이터 추출
+      console.log(announcement);
+
+      this.renderSingleAnnouncement(announcement);
+    } catch (error) {
+      console.error('추가 공지사항 데이터를 가져오는 중 에러 발생:', error);
+    }
+  }
+
+  renderSingleAnnouncement(announcement) {
+    const announcementContainer = this.$container.querySelector(
+      '.announcement-content',
+    );
+
+    if (!announcement.imageUrl) {
+      const announcementElement = document.createElement('div');
+      announcementElement.classList.add('announcement-item');
+
+      announcementElement.innerHTML = /* HTML */ `
+        <div class="announcement-content">
+          <p class="announcement-content">
+            ${announcement.content.replaceAll('\n', '<br />')}
+          </p>
+        </div>
+      `;
+
+      announcementContainer.appendChild(announcementElement);
+    }
   }
 }

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -116,14 +116,14 @@ export default class HomePage extends Container {
       </div>
     `;
 
-    // 공지사항 데이터 가져오기 및 UI 업데이트
+    // 공지사항 데이터 가져오기
     try {
       const response = await axios.get('/api/announcements'); // axios를 사용하여 데이터 가져오기
       const announcements = response.data.data; // 데이터 추출
 
       this.renderAnnouncements(announcements);
       // 추가적인 공지사항 불러오기
-      this.renderAdditionalAnnouncement();
+      this.renderAdditionalAnnouncements(announcements);
     } catch (error) {
       console.error('공지사항 데이터를 가져오는 중 에러 발생:', error);
     }
@@ -154,36 +154,30 @@ export default class HomePage extends Container {
     });
   }
 
-  async renderAdditionalAnnouncement() {
-    try {
-      const response = await axios.get('/api/announcements/6'); // announcementId가 6인 공지사항을 가져옵니다.
-      const announcement = response.data.data; // 데이터 추출
-      console.log(announcement);
-
-      this.renderSingleAnnouncement(announcement);
-    } catch (error) {
-      console.error('추가 공지사항 데이터를 가져오는 중 에러 발생:', error);
-    }
-  }
-
-  renderSingleAnnouncement(announcement) {
+  renderAdditionalAnnouncements(announcements) {
     const announcementContainer = this.$container.querySelector(
       '.announcement-content',
     );
 
-    if (!announcement.imageUrl) {
-      const announcementElement = document.createElement('div');
-      announcementElement.classList.add('announcement-item');
+    announcementContainer.innerHTML = '';
 
-      announcementElement.innerHTML = /* HTML */ `
-        <div class="announcement-content">
-          <p class="announcement-content">
-            ${announcement.content.replaceAll('\n', '<br />')}
-          </p>
-        </div>
-      `;
+    announcements.forEach((item) => {
+      if (!item.imageUrl) {
+        const announcementElement = document.createElement('div');
+        announcementElement.classList.add('announcement-item');
 
-      announcementContainer.appendChild(announcementElement);
-    }
+        announcementElement.innerHTML = /* HTML */ `
+          <p>${item.content.replaceAll('\n', '<br />')}</p>
+        `;
+
+        announcementContainer.appendChild(announcementElement);
+      }
+    });
   }
 }
+
+// 사용 예시
+document.addEventListener('DOMContentLoaded', () => {
+  const homePageInstance = new HomePage();
+  homePageInstance.render();
+});

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -176,7 +176,6 @@ export default class HomePage extends Container {
   }
 }
 
-// 사용 예시
 document.addEventListener('DOMContentLoaded', () => {
   const homePageInstance = new HomePage();
   homePageInstance.render();


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

[feat] 홈페이지 주요사항을 실제데이터로 변경

## 📋 작업 내용

- 주요소식 공지사항을 실제 데이터로 변경하였습니다.

- css를 모바일버전 기준으로 작성하고 미디어쿼리를 데스크탑으로 바꿨습니다.

- ${dummyUserProfile.name}넣어서 이름 출력

다은님이 지정해두신 anouncement-content css 를
(margin-top: 20px;
  margin-bottom: 25px;
  margin-left: 15px;) 에서

(  padding-top: 10px;
  padding-bottom: 10px;
  margin-left: 0;
  margin-right: 0;
  padding-left: 0;
  padding-right: 0;)
이렇게도 수정했는데 문제시 말씀해주세요 !

## 🔧 변경 사항

home.js와 home.css가 변경되었습니다.
home.js 주요사항에서 announcement.json 중 6번째 공지사항만 불러오도록 설정하였습니다.

## 📸 스크린샷 (선택 사항)

<img width="456" alt="스크린샷 2024-07-07 오후 7 22 50" src="https://github.com/Dev-FE-1/idle-intranet-service/assets/170427166/f3927a91-d954-4480-9922-8ee97278c215">
<img width="751" alt="스크린샷 2024-07-07 오후 7 23 55" src="https://github.com/Dev-FE-1/idle-intranet-service/assets/170427166/15ac1aff-53ed-425a-9593-16996b300221">

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
