### PR TITLE
[Refactor] 홈페이지 리팩토링

### DIFF
--- a/src/api/endpoints/announcement.js
+++ b/src/api/endpoints/announcement.js
@@ -1,0 +1,15 @@
+import { apiCall } from '../apiClient.js';
+import { API_ENDPOINTS } from '../config.js';
+
+export async function fetchAnnouncements() {
+  try {
+    const response = await apiCall({
+      endpoint: API_ENDPOINTS.ANNOUNCEMENTS,
+      method: 'get',
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch announcements:', error);
+    throw error;
+  }
+}

--- a/src/api/endpoints/member.js
+++ b/src/api/endpoints/member.js
@@ -1,0 +1,16 @@
+import { apiCall } from '../apiClient.js';
+import { API_ENDPOINTS } from '../config.js';
+
+export async function fetchMember(id, isAdmin = false) {
+  try {
+    const response = await apiCall({
+      endpoint: `${API_ENDPOINTS.MEMBER}/${id}`,
+      method: 'get',
+      params: { isAdmin },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch user:', error);
+    throw error;
+  }
+}

--- a/src/components/Announcements/GalleryItem.js
+++ b/src/components/Announcements/GalleryItem.js
@@ -8,9 +8,9 @@ export default class GalleryItem {
   html() {
     return /* HTML */ `
       <li class="gallery-item">
-        <a href="${PATH.ANNOUNCEMENT}/${this.item.id}">
+        <a href="${PATH.ANNOUNCEMENT}/${this.item.announcementId}">
           <div class="gallery-image-box">
-            <img src="${this.item.imageUrl}" alt="${this.item.title}" />
+            <img src="./${this.item.imageUrl}" alt="${this.item.title}" />
           </div>
           <div class="gallery-content-box">
             <h2>${this.item.title}</h2>

--- a/src/components/Announcements/GalleryItem.js
+++ b/src/components/Announcements/GalleryItem.js
@@ -1,0 +1,23 @@
+import { PATH } from '../../utils/constants.js';
+
+export default class GalleryItem {
+  constructor(item) {
+    this.item = item;
+  }
+
+  html() {
+    return /* HTML */ `
+      <li class="gallery-item">
+        <a href="${PATH.ANNOUNCEMENT}/${this.item.id}">
+          <div class="gallery-image-box">
+            <img src="${this.item.imageUrl}" alt="${this.item.title}" />
+          </div>
+          <div class="gallery-content-box">
+            <h2>${this.item.title}</h2>
+            <p class="gallery-content">${this.item.content}</p>
+          </div>
+        </a>
+      </li>
+    `;
+  }
+}

--- a/src/components/Announcements/TextItem.js
+++ b/src/components/Announcements/TextItem.js
@@ -13,9 +13,15 @@ export default class TextItem {
     }
 
     const $container = document.querySelector(
-      `#announcement-${this.item.announcementId} .author-image-container`,
+      `#announcement-${this.item.announcementId}`,
     );
-    $container.innerHTML = new Avatar({ url: this.author.profileImage }).html();
+    const $avatar = $container.querySelector('.author-image-container');
+    const $name = $container.querySelector('.announcement-author-name');
+
+    $avatar.innerHTML = new Avatar({
+      url: this.author.profileImage,
+    }).html();
+    $name.innerText = this.author.name;
   }
 
   render() {
@@ -23,13 +29,15 @@ export default class TextItem {
   }
 
   html() {
+    const postedDate = this.item.postedDate.split('-').slice(1).join('/');
+
     return /* HTML */ `
       <li id="announcement-${this.item.announcementId}">
         <div class="announcement-author">
           <div class="author-image-container"></div>
           <div class="announcement-info">
-            <div class="announcement-author-name">안민지</div>
-            <div class="announcement-time">약 15시간 전</div>
+            <div class="announcement-author-name"></div>
+            <div class="announcement-time">${postedDate}</div>
           </div>
         </div>
         <div class="announcement-content">

--- a/src/components/Announcements/TextItem.js
+++ b/src/components/Announcements/TextItem.js
@@ -1,0 +1,41 @@
+import { fetchMember } from '../../api/endpoints/member.js';
+import Avatar from '../Avatar/Avatar.js';
+
+export default class TextItem {
+  constructor(item) {
+    this.item = item;
+    this.author = null;
+  }
+
+  async renderAuthor() {
+    if (!this.author) {
+      this.author = await fetchMember(this.item.employeeNumber);
+    }
+
+    const $container = document.querySelector(
+      `#announcement-${this.item.announcementId} .author-image-container`,
+    );
+    $container.innerHTML = new Avatar({ url: this.author.profileImage }).html();
+  }
+
+  render() {
+    this.renderAuthor();
+  }
+
+  html() {
+    return /* HTML */ `
+      <li id="announcement-${this.item.announcementId}">
+        <div class="announcement-author">
+          <div class="author-image-container"></div>
+          <div class="announcement-info">
+            <div class="announcement-author-name">안민지</div>
+            <div class="announcement-time">약 15시간 전</div>
+          </div>
+        </div>
+        <div class="announcement-content">
+          <p>${this.item.content.replaceAll('\n', '<br />')}</p>
+        </div>
+      </li>
+    `;
+  }
+}

--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -93,14 +93,6 @@
   color: var(--color-dark-gray);
 }
 
-.gallery-more-button-container button {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 4px;
-  margin-top: 12px;
-}
-
 /* announcement */
 .announcement-contents {
   padding-bottom: 50px;
@@ -166,9 +158,5 @@
 
   .home-container .gallery-item .gallery-content-box {
     padding: 16px;
-  }
-
-  .gallery-more-button-container {
-    display: none;
   }
 }

--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -102,17 +102,19 @@
 }
 
 /* announcement */
+.announcement-contents {
+  padding-bottom: 50px;
+}
+
 .announcement-author {
   display: flex;
   gap: 12px;
 }
 
 .announcement-content {
-  margin-top: 20px;
-  margin-bottom: 25px;
-  margin-left: 15px;
-  padding-bottom: 60px;
+  padding: 20px 0 10px;
   color: var(--color-darkest-gray);
+  line-height: 1.6;
 }
 
 .announcement-author .author-image-container .profile-img-container {
@@ -136,10 +138,6 @@
   .home-container .gallery {
     grid-template-columns: repeat(2, 1fr);
   }
-
-  .announcement-contents {
-    padding-bottom: 50px;
-  }
 }
 
 /* desktop */
@@ -159,10 +157,6 @@
 
   .home-container .gallery {
     grid-template-columns: repeat(3, 1fr);
-  }
-
-  .home-container .gallery-image-box {
-    aspect-ratio: 1/1;
   }
 
   .home-container .gallery a:hover .gallery-image-box img {

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -11,32 +11,6 @@ import { COLORS } from '../../utils/constants.js';
 import logo from '../../../public/images/logo.svg';
 import './Home.css';
 
-const dummyUserProfile = {
-  employeeNumber: 101,
-  name: '안민지',
-  position: 'Software Engineer',
-  hireDate: '2015-10-11',
-  birthDate: '1987-05-08',
-  address: '경상북도 안산시 단원구 반포대거리',
-  email: 'anminji@cubeit.com',
-  phoneNumber: '010-7583-2446',
-  salary: 69000000,
-  isAdmin: true,
-  departmentNumber: 20,
-  education: '성균관대학교 소프트웨어공학 학사',
-  career: [
-    {
-      companyName: '카카오',
-      period: '2012-04-06 ~ 2014-07-02',
-      role: '백엔드 개발자',
-    },
-  ],
-  role: '백엔드 개발자',
-  profileImage:
-    'https://api.dicebear.com/9.x/lorelei/svg?seed=Max&eyes=variant09',
-  remainingVacationDays: 11,
-};
-
 export default class HomePage extends Container {
   constructor() {
     super('#main');
@@ -47,19 +21,14 @@ export default class HomePage extends Container {
         'Cube.IT은 작은 아이디어로 큰 변화를 만들어갑니다. 혁신적인 큐브의 힘을 경험해 보세요.',
     });
 
-    // WorkInfo 객체를 생성
-    this.PersonalInfo = new PersonalInfo({ user: dummyUserProfile });
-
-    // 버튼 아이콘
+    this.PersonalInfo = new PersonalInfo();
     this.buttonIcon = new Icon({
       svg: chevronDown,
       options: { color: COLORS.DARKEST_GRAY },
     });
-
-    // Button 인스턴스 생성
     this.moreButton = new Button({
       variant: 'tertiary',
-      content: `${this.buttonIcon.html()}더 보기`,
+      content: `${this.buttonIcon.html()} 더 보기`,
     });
   }
 
@@ -104,9 +73,7 @@ export default class HomePage extends Container {
                 }).html()}
               </div>
               <div class="announcement-info">
-                <div class="announcement-author-name">
-                  ${dummyUserProfile.name}
-                </div>
+                <div class="announcement-author-name">안민지</div>
                 <div class="announcement-time">약 15시간 전</div>
               </div>
             </div>
@@ -116,6 +83,7 @@ export default class HomePage extends Container {
       </div>
     `;
 
+    this.PersonalInfo.render();
     // 공지사항 데이터 가져오기
     try {
       const response = await axios.get('/api/announcements'); // axios를 사용하여 데이터 가져오기

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,13 +1,9 @@
 import Container from '../../components/Container.js';
 import Title from '../../components/Title/Title.js';
 import PersonalInfo from '../../components/PersonalInfo/PersonalInfo.js';
-import Button from '../../components/Button/Button.js';
-import Icon from '../../components/Icon/Icon.js';
-import { chevronDown } from '../../utils/icons.js';
 import logo from '../../../public/images/logo.svg';
 import GalleryItem from '../../components/Announcements/GalleryItem.js';
 import TextItem from '../../components/Announcements/TextItem.js';
-import { COLORS } from '../../utils/constants.js';
 import { fetchAnnouncements } from '../../api/endpoints/announcement.js';
 import './Home.css';
 
@@ -21,14 +17,6 @@ export default class HomePage extends Container {
         'Cube.IT은 작은 아이디어로 큰 변화를 만들어갑니다. 혁신적인 큐브의 힘을 경험해 보세요.',
     });
     this.PersonalInfo = new PersonalInfo();
-    this.buttonIcon = new Icon({
-      svg: chevronDown,
-      options: { color: COLORS.DARKEST_GRAY },
-    });
-    this.moreButton = new Button({
-      variant: 'tertiary',
-      content: `${this.buttonIcon.html()} 더 보기`,
-    });
   }
 
   async setAnnouncements() {
@@ -103,10 +91,6 @@ export default class HomePage extends Container {
             <ul class="gallery"></ul>
           </div>
         </section>
-
-        <div class="gallery-more-button-container wrapper">
-          ${this.moreButton.html()}
-        </div>
 
         <section class="announcement-container">
           <div class="wrapper">

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,7 +12,7 @@ const baseUrl = import.meta.env.VITE_BASE_URL || '';
 export const PATH = {
   SIGNIN: `${baseUrl}/signin`,
   HOME: `${baseUrl}/`,
-  ANNOUNCEMENT: `${baseUrl}/announcements/:id`,
+  ANNOUNCEMENT: `${baseUrl}/announcements`,
   MEMBER: `${baseUrl}/members/:id`,
   MEMBERS: `${baseUrl}/members`,
   PROFILE: `${baseUrl}/profile`,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- 홈페이지 리팩토링 작업 했습니다!

## 📋 작업 내용

- GallertyItem과 TextItem 컴포넌트로 분리
- PersonalInfo 실제 데이터로 변경 및 더미데이터 삭제

## 🔧 변경 사항

- 홈페이지에서 필요한 fetch 함수를 `api/endpoints` 폴더에 추가해 사용했습니다
- 더보기 버튼을 삭제했습니다

## 📸 스크린샷 (선택 사항)

![image](https://github.com/Dev-FE-1/idle-intranet-service/assets/108856689/fe7283c3-88f9-4e71-bbb4-84ce242d9a73)

## 📄 기타

공지사항 전체(갤러리, 텍스트)를 컴포넌트로 분리하면 좋을 것 같은데 난아님 도전 과제...?