### PR TITLE
[help] render() 내 비동기 순서 보장과 $container.innerHTML 사용이 헷갈림

### DIFF
--- a/src/api/endpoints/vacationRequests.js
+++ b/src/api/endpoints/vacationRequests.js
@@ -1,0 +1,23 @@
+import { apiCall } from '../apiClient.js';
+import { API_ENDPOINTS } from '../config.js';
+
+export async function fetchVacationRequests(
+  employeeNumber,
+  page = 1,
+  max = 10,
+) {
+  try {
+    const response = await apiCall({
+      endpoint: `${API_ENDPOINTS.VACATION_REQUESTS}/${page}`,
+      method: 'get',
+      params: { employeeNumber, max },
+    });
+    return response.data;
+  } catch (error) {
+    console.error(
+      `Failed to fetch vacation requests for employee ${employeeNumber}:`,
+      error,
+    );
+    throw error;
+  }
+}

--- a/src/components/WorkManagement/ManagementSection.css
+++ b/src/components/WorkManagement/ManagementSection.css
@@ -1,0 +1,19 @@
+.management-section-container {
+  padding: 30px 0;
+  margin-top: 12px;
+  background-color: white;
+}
+
+.management-section-title {
+  padding-bottom: 30px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+@media (width >= 1024px) {
+  .management-section-container {
+    padding: 0;
+    margin-top: 36px;
+    background-color: white;
+  }
+}

--- a/src/components/WorkManagement/ManagementSection.js
+++ b/src/components/WorkManagement/ManagementSection.js
@@ -1,0 +1,20 @@
+import './ManagementSection.css';
+
+export default class ManagementSection {
+  constructor({ title, contents }) {
+    this.title = title;
+    this.contents = contents;
+  }
+
+  html() {
+    const allContents = this.contents.join('');
+    return `
+      <section class="management-section-container">
+        <div class="wrapper">
+          <h3 class="management-section-title">${this.title}</h3>
+          ${allContents}
+        </div>
+      </section>
+    `;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCard.css
+++ b/src/components/WorkManagement/VacationTab/VacationCard.css
@@ -1,0 +1,62 @@
+.vacation-card {
+  min-height: 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.vacation-card-type-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vacation-card-icon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  margin-right: 10px;
+}
+
+.vacation-card-info-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vacation-card-days {
+  margin-right: 7px;
+  color: var(--color-darkest-gray);
+  font-weight: 500;
+  text-align: right;
+}
+
+.next-arrow-icon {
+  display: flex;
+  margin-right: -3px;
+}
+
+@media (width >= 1024px) {
+  .vacation-card {
+    padding: 20px;
+    width: calc((100% / 3) - 9px);
+    border: 1px solid var(--color-light-gray);
+    border-radius: 4px;
+  }
+
+  .vacation-card:hover {
+    background-color: var(--color-lightest-gray);
+  }
+
+  .next-arrow-icon {
+    display: none;
+  }
+
+  .vacation-card-days {
+    margin-right: 0;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCard.js
+++ b/src/components/WorkManagement/VacationTab/VacationCard.js
@@ -1,0 +1,39 @@
+import { chevronRight } from '../../../utils/icons.js';
+import { COLORS } from '../../../utils/constants.js';
+import Icon from '../../Icon/Icon.js';
+import './VacationCard.css';
+
+export default class VacationCard {
+  constructor({ vacationData }) {
+    if (!vacationData) throw new Error('vacationData is required');
+
+    this.vacationData = vacationData;
+    this.chevronRight = new Icon({
+      svg: chevronRight,
+      options: { size: '24px', color: COLORS.DARK_GRAY },
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  createIconHtml(icon) {
+    return `<div class="vacation-card-icon">${icon}</div>`;
+  }
+
+  html() {
+    const { icon, type, days } = this.vacationData;
+    const chevronHtml = this.chevronRight.html();
+
+    return `
+      <li class="vacation-card">
+        <div class="vacation-card-type-box">
+          ${this.createIconHtml(icon)}
+          <p class="vacation-card-type">${type}</p>
+        </div>
+        <div class="vacation-card-info-box">
+          <p class="vacation-card-days">${days}</p>
+          <div class="next-arrow-icon">${chevronHtml}</div>
+        </div>
+      </li>
+    `;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCards.css
+++ b/src/components/WorkManagement/VacationTab/VacationCards.css
@@ -1,0 +1,8 @@
+@media (width >= 1024px) {
+  .vacation-cards {
+    width: 100%;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCards.js
+++ b/src/components/WorkManagement/VacationTab/VacationCards.js
@@ -1,0 +1,23 @@
+import './VacationCards.css';
+import VacationCard from './VacationCard.js';
+import { vacationArray } from '../../../utils/vacation.js';
+import ManagementSection from '../ManagementSection.js';
+
+export default class VacationCards {
+  constructor() {
+    const vacationHTML = vacationArray
+      .map((vacationData) => new VacationCard({ vacationData }).html())
+      .join('');
+
+    const listhtml = `<ul class="vacation-cards">${vacationHTML}</ul>`;
+
+    this.managementSection = new ManagementSection({
+      title: '휴가 신청하기',
+      contents: [listhtml],
+    });
+  }
+
+  render() {
+    return this.managementSection.html();
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistories.css
+++ b/src/components/WorkManagement/VacationTab/VacationHistories.css
@@ -1,0 +1,30 @@
+.vacation-histories-container {
+  padding: 30px 0;
+  margin-top: 12px;
+  background-color: white;
+}
+
+.vacation-histories-header {
+  padding-bottom: 22px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.vacation-histories-title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+@media (width >= 1024px) {
+  .vacation-histories-header {
+    max-width: 300px;
+  }
+
+  .vacation-histories-container {
+    padding: 0;
+    margin-top: 48px;
+    margin-bottom: 48px;
+    background-color: white;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistories.js
+++ b/src/components/WorkManagement/VacationTab/VacationHistories.js
@@ -1,0 +1,76 @@
+import './VacationHistories.css';
+import VacationHistory from './VacationHistory.js';
+import Select from '../../Select/Select.js';
+import { fetchVacationRequests } from '../../../api/endpoints/vacationRequests.js';
+import { vacationTypes } from '../../../utils/vacation.js';
+import { storeInstance } from '../../Store.js';
+
+export default class VacationHistories {
+  constructor() {
+    this.store = storeInstance;
+    this.isLoading = true;
+    this.VacationSelect = new Select({
+      contents: vacationTypes,
+      onSelect: (selectedItem) => console.log('Selected:', selectedItem),
+      roundedBorder: true,
+    });
+  }
+
+  async setVacation() {
+    if (!this.user) {
+      this.user = await this.store.getUser();
+    }
+    this.vacations = await fetchVacationRequests(this.user.employeeNumber);
+  }
+
+  async initContainer() {
+    this.$container = document.querySelector('.vacation-histories-container');
+    if (!this.$container) {
+      this.$container = document.createElement('section');
+      this.$container.className = 'vacation-histories-container';
+      document.querySelector('#main').appendChild(this.$container);
+    }
+
+    const headerHtml = /* HTML */ `
+      <section class="vacation-histories-container">
+        <div class="wrapper">
+          <div class="vacation-histories-header">
+            <h3 class="vacation-histories-title">사용 기록</h3>
+            ${this.VacationSelect.html()}
+          </div>
+          <ul class="vacation-histories-list"></ul>
+        </div>
+      </section>
+    `;
+
+    this.$container.innerHTML = headerHtml;
+    this.VacationSelect.setEventListeners();
+  }
+
+  async renderVacations() {
+    const listContainer = this.$container.querySelector(
+      '.vacation-histories-list',
+    );
+    if (!listContainer) {
+      console.error('Cannot find the vacation history list container.');
+      return;
+    }
+
+    if (!this.vacations) {
+      await this.setVacation();
+    }
+
+    listContainer.innerHTML = this.vacations
+      .map((vacation) => new VacationHistory(vacation).render())
+      .join('');
+  }
+
+  async render() {
+    if (!this.$container) {
+      await this.initContainer();
+    }
+
+    await this.setVacation();
+    await this.renderVacations();
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistory.css
+++ b/src/components/WorkManagement/VacationTab/VacationHistory.css
@@ -1,0 +1,71 @@
+.vacation-history {
+  min-height: 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.vacation-history-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.vacation-history-type-box {
+  display: flex;
+  align-items: center;
+}
+
+.vacation-history-type-icon-box {
+  margin-right: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+}
+
+.vacation-history-type-icon {
+  margin-bottom: 5px;
+}
+
+.vacation-history-type {
+  margin-right: 10px;
+}
+
+.vacation-history-approval-status {
+  padding: 4px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  background-color: var(--color-primary);
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 4px;
+}
+
+.vacation-application-date {
+  font-size: 14px;
+  color: var(--color-darkest-gray);
+}
+
+@media (width >= 1024px) {
+  .vacation-history {
+    max-width: 300px;
+  }
+
+  .vacation-application-date {
+    position: relative;
+  }
+
+  .vacation-application-date::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: -27px;
+    transform: translate(0, -50%);
+    width: 2px;
+    height: 12px;
+    background-color: var(--color-light-gray);
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistory.js
+++ b/src/components/WorkManagement/VacationTab/VacationHistory.js
@@ -1,0 +1,38 @@
+import { vacationArray } from '../../../utils/vacation.js';
+import './VacationHistory.css';
+
+export default class VacationHistory {
+  constructor(VacationHistoryData) {
+    this.vacationHistoryData = VacationHistoryData;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getIcon(vacationType) {
+    const vacation = vacationArray.find((v) => v.type === vacationType);
+    return vacation ? vacation.icon : '';
+  }
+
+  render() {
+    const icon = this.getIcon(this.vacationHistoryData.vacationType);
+    return /* HTML */ `
+      <li class="vacation-history">
+        <div class="vacation-history-container">
+          <div class="vacation-history-type-box">
+            <div class="vacation-history-type-icon-box">
+              <span class="vacation-history-type-icon">${icon}</span>
+            </div>
+            <p class="vacation-history-type">
+              ${this.vacationHistoryData.vacationType}
+            </p>
+          </div>
+          <span class="vacation-history-approval-status">
+            ${this.vacationHistoryData.approvalStatus}
+          </span>
+        </div>
+        <p class="vacation-application-date">
+          ${this.vacationHistoryData.vacationRequestDate}
+        </p>
+      </li>
+    `;
+  }
+}

--- a/src/components/WorkManagement/WorkingTab.js
+++ b/src/components/WorkManagement/WorkingTab.js
@@ -1,0 +1,30 @@
+import Table from '../Table/Table.js';
+import ManagementSection from './ManagementSection.js';
+
+export default class WorkingTab {
+  constructor() {
+    this.contents = [];
+    const transformedEmployees = this.contents.map((employee) => [
+      employee.name,
+      employee.position,
+      employee.departmentName,
+      employee.email,
+      employee.phoneNumber,
+    ]);
+    this.table = new Table({
+      headers: ['날짜', '출근 시각', '퇴근 시각', '주간 근무 시간'],
+      contents: transformedEmployees,
+    });
+
+    this.managementSection = new ManagementSection({
+      title: '근무내역',
+      contents: [
+        `<div class="work-history-container">${this.table.html()}</div>`,
+      ],
+    });
+  }
+
+  render() {
+    return this.managementSection.html();
+  }
+}

--- a/src/pages/WorkManage/WorkManage.css
+++ b/src/pages/WorkManage/WorkManage.css
@@ -1,0 +1,43 @@
+.work-manage-header-container {
+  background-color: #fff;
+}
+
+.work-manage-menu-list {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  font-weight: 700;
+}
+
+.work-manage-menu-item {
+  height: 100%;
+  padding: 20px 0 15px;
+  color: var(--color-dark-gray);
+  cursor: pointer;
+}
+
+.work-manage-menu-item + .work-manage-menu-item {
+  margin-left: 28px;
+}
+
+.work-manage-menu-list li.active {
+  border-bottom: 2px solid var(--color-primary);
+  color: var(--color-black);
+}
+
+@media (width >= 1024px) {
+  .work-manage-menu-list {
+    position: relative;
+  }
+
+  .work-manage-menu-list::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 50%;
+    transform: translate(-50%, 0%);
+    width: calc(100% - (20px * 2));
+    height: 2px;
+    background-color: var(--color-light-gray);
+  }
+}

--- a/src/pages/WorkManage/WorkManage.js
+++ b/src/pages/WorkManage/WorkManage.js
@@ -1,19 +1,70 @@
+import './WorkManage.css';
 import Container from '../../components/Container.js';
 import Title from '../../components/Title/Title.js';
+import VacationCards from '../../components/WorkManagement/VacationTab/VacationCards.js';
+import VacationHistories from '../../components/WorkManagement/VacationTab/VacationHistories.js';
+import WorkingTab from '../../components/WorkManagement/WorkingTab.js';
 import { PATH_TITLE } from '../../utils/constants.js';
-import './WorkManage.css';
 
 export default class WorkManagePage extends Container {
   constructor() {
     super('#main');
-    this.Title = new Title({
-      title: PATH_TITLE.WORK_MANAGE,
+    this.Title = new Title({ title: PATH_TITLE.WORK_MANAGE });
+    this.vacationCards = new VacationCards();
+    this.vacationHistories = new VacationHistories();
+    this.workingTab = new WorkingTab();
+    this.$container = document.querySelector('.work-manage-content');
+  }
+
+  addEventListeners() {
+    const menu = this.$container.querySelector('.work-manage-menu-list');
+    menu.addEventListener('click', async (event) => {
+      const { target } = event;
+      const { id: targetId } = target;
+      const contentContainer = this.$container.querySelector(
+        '#work-manage-content',
+      );
+
+      if (!targetId) return;
+
+      if (targetId === 'work-management') {
+        contentContainer.innerHTML = this.workingTab.render();
+      } else if (targetId === 'vacation-management') {
+        await this.vacationHistories.render(); // 비동기 작업을 기다림
+        contentContainer.innerHTML = `${this.vacationCards.render()}${this.vacationHistories.$container.innerHTML}`;
+      }
+      this.updateActiveMenuItem(targetId);
     });
   }
 
-  render() {
+  updateActiveMenuItem(activeId) {
+    const menuItems = this.$container.querySelectorAll(
+      '.work-manage-menu-item',
+    );
+    menuItems.forEach((item) => item.classList.remove('active'));
+    const activeItem = this.$container.querySelector(`#${activeId}`);
+    if (activeItem) {
+      activeItem.classList.add('active');
+    }
+  }
+
+  async render() {
+    await this.vacationHistories.initContainer();
+    await this.vacationHistories.render();
+
     this.$container.innerHTML = `
-      ${this.Title.html()}
+      <div class="work-manage-header-container">
+        ${this.Title.html()}
+        <ul class="work-manage-menu-list wrapper">
+          <li class="work-manage-menu-item" id="work-management">근무 관리</li>
+          <li class="work-manage-menu-item active" id="vacation-management">휴가 관리</li>
+        </ul>
+      </div>
+      <div id="work-manage-content" class="work-manage-content">
+        ${this.vacationCards.render()}
+        ${this.vacationHistories.$container.innerHTML} 
+      </div>
     `;
+    this.addEventListeners();
   }
 }

--- a/src/utils/vacation.js
+++ b/src/utils/vacation.js
@@ -1,0 +1,74 @@
+export const vacationArray = [
+  {
+    icon: '🌴',
+    type: '연차',
+    days: '17일',
+  },
+  {
+    icon: '💼',
+    type: '반차',
+    days: '3시간',
+  },
+  {
+    icon: '🤰🏻',
+    type: '출산 휴가',
+    days: '90일',
+  },
+  {
+    icon: '🫃🏻',
+    type: '배우자 출산 휴가',
+    days: '30일',
+  },
+  {
+    icon: '🎀',
+    type: '여성휴가',
+    days: '1일',
+  },
+  {
+    icon: '👥',
+    type: '가족 돌봄 휴가',
+    days: '1일',
+  },
+  {
+    icon: '👤',
+    type: '기타 휴가',
+    days: '1일',
+  },
+];
+
+export const vacationTypes = [
+  '전체 휴가',
+  '연차',
+  '반차',
+  '출산 휴가',
+  '배우자 출산 휴가',
+  '여성 휴가',
+  '가족 돌봄 휴가',
+  '기타휴가',
+];
+
+export const vacationDaysOptions = [
+  '0일',
+  '1일',
+  '2일',
+  '3일',
+  '4일',
+  '6일',
+  '7일',
+  '8일',
+];
+export const availableStartTimes = [
+  '00:00',
+  '09:00',
+  '10:00',
+  '11:00',
+  '12:00',
+  '13:00',
+  '14:00',
+  '15:00',
+  '16:00',
+  '17:00',
+  '18:00',
+];
+
+export const hourIncrements = ['0시간', '1시간', '2시간', '3시간', '4시간'];


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**render() 내 비동기 순서 보장과 $container.innerHTML 사용이 헷갈림**

## 📋 작업 내용

근무/휴가 페이지 화면을 렌더링을 함. 
근무내역은 실제 데이터 안붙힘... 주요한건 사용기록, 휴가신청 이니깐....

아침에 PR을 해야겠다는 생각이 들어서 모달까지 붙혀서 보여주려고 했으나
휴가 신청하기, 사용기록.. 그 페이지가 비동기 파티라 화면에 렌더링이 안되고 난리남.
그래서 모달만 삭제하고 보여드려야지 했지만 어디서 뭘  잘못했는지 안나옴ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ

아 그리고 $container.innerHTML 저는 이게 최상위 container라고 생각했는데 잘게 쪼갤수록 $container.innerHTML에 대한 의미도 달라지는것 같더라구요? 그래서 자꾸 null값이라고... 너 없다고... 뜸... html 하면 비동기라서 안나오고.... 

사용기록api도 맘에 안드는데.... 렌더링부터...ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ 렌더링이 왜 안되냐구....! 심지어 근무내역 api 붙히면 화면 안나올까봐...안붙혔는데....


## 📸 스크린샷 (선택 사항)
![스크린샷 2024-07-11 오전 7 59 04](https://github.com/Dev-FE-1/idle-intranet-service/assets/89791868/c3361ce9-ea3f-4974-8fbd-a5e8f8307977)

