### PR TITLE
[Feat]휴가/근무 퍼블리싱, api 적용

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -164,7 +164,6 @@ const initializeDatabase = () => {
             vacationStartTime TEXT NOT NULL,
             vacationEndTime TEXT NOT NULL,
             vacationReason TEXT NOT NULL,
-            position TEXT NOT NULL,
             approvalStatus TEXT NOT NULL,
             usageStatus TEXT NOT NULL,
             vacationType TEXT NOT NULL,
@@ -177,9 +176,9 @@ const initializeDatabase = () => {
           INSERT OR IGNORE INTO vacationRequests (
             employeeNumber, departmentNumber, vacationRequestDate,
             vacationStartDate, vacationEndDate, vacationStartTime, 
-            vacationEndTime, vacationReason, position, approvalStatus,
+            vacationEndTime, vacationReason, approvalStatus,
             usageStatus, vacationType
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `);
 
         vacationRequests.forEach((request) => {
@@ -192,7 +191,6 @@ const initializeDatabase = () => {
             request.vacationStartTime,
             request.vacationEndTime,
             request.vacationReason,
-            request.position,
             request.approvalStatus,
             request.usageStatus,
             request.vacationType,

--- a/src/api/endpoints/attendance.js
+++ b/src/api/endpoints/attendance.js
@@ -1,0 +1,16 @@
+import { apiCall } from '../apiClient.js';
+import { API_ENDPOINTS } from '../config.js';
+
+export async function fetchAttendances(employeeNumber, page = 1, max = 10) {
+  try {
+    const response = await apiCall({
+      endpoint: `${API_ENDPOINTS.ATTENDANCE}/${page}`,
+      method: 'get',
+      params: { employeeNumber, max },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch user weekly attendances:', error);
+    throw error;
+  }
+}

--- a/src/api/endpoints/vacationRequests.js
+++ b/src/api/endpoints/vacationRequests.js
@@ -1,0 +1,85 @@
+import { apiCall } from '../apiClient.js';
+import { API_ENDPOINTS } from '../config.js';
+
+export async function fetchVacationRequests(
+  employeeNumber,
+  page = 1,
+  max = 10,
+) {
+  try {
+    const response = await apiCall({
+      endpoint: `${API_ENDPOINTS.VACATION_REQUESTS}/${page}`,
+      method: 'get',
+      params: { employeeNumber, max },
+    });
+    return response.data;
+  } catch (error) {
+    console.error(
+      `Failed to fetch vacation requests for employee ${employeeNumber}:`,
+      error,
+    );
+    throw error;
+  }
+}
+
+export async function updateAttendance(
+  employeeNumber,
+  date,
+  startTime,
+  endTime,
+  status,
+) {
+  try {
+    const response = await apiCall({
+      endpoint: API_ENDPOINTS.ATTENDANCE,
+      method: 'put',
+      data: {
+        employeeNumber,
+        date,
+        startTime,
+        endTime,
+        status,
+      },
+      auth: true,
+    });
+    return response;
+  } catch (error) {
+    console.error('Failed to update profile:', error);
+    throw error;
+  }
+}
+
+export async function updateVacationRequests({
+  employeeNumber,
+  departmentNumber,
+  vacationStartDate,
+  vacationEndDate,
+  approvalStatus = '미승인',
+  vacationType,
+  vacationStartTime,
+  vacationEndTime,
+  vacationReason,
+}) {
+  try {
+    const response = await apiCall({
+      endpoint: API_ENDPOINTS.VACATION_REQUESTS,
+      method: 'put',
+      data: {
+        employeeNumber,
+        departmentNumber,
+        vacationStartDate,
+        vacationEndDate,
+        approvalStatus,
+        vacationType,
+        vacationStartTime,
+        vacationEndTime,
+        vacationReason,
+      },
+      auth: true,
+    });
+    return response;
+  } catch (error) {
+    console.error('Failed to update profile:', error);
+    throw error;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCard.css
+++ b/src/components/WorkManagement/VacationTab/VacationCard.css
@@ -1,0 +1,62 @@
+.vacation-card {
+  min-height: 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.vacation-card-type-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vacation-card-icon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  margin-right: 10px;
+}
+
+.vacation-card-info-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vacation-card-days {
+  margin-right: 7px;
+  color: var(--color-darkest-gray);
+  font-weight: 500;
+  text-align: right;
+}
+
+.next-arrow-icon {
+  display: flex;
+  margin-right: -3px;
+}
+
+@media (width >= 1024px) {
+  .vacation-card {
+    padding: 20px;
+    width: calc((100% / 3) - 9px);
+    border: 1px solid var(--color-light-gray);
+    border-radius: 4px;
+  }
+
+  .vacation-card:hover {
+    background-color: var(--color-lightest-gray);
+  }
+
+  .next-arrow-icon {
+    display: none;
+  }
+
+  .vacation-card-days {
+    margin-right: 0;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCard.js
+++ b/src/components/WorkManagement/VacationTab/VacationCard.js
@@ -1,0 +1,29 @@
+import { chevronRight } from '../../../utils/icons.js';
+import { COLORS } from '../../../utils/constants.js';
+import Icon from '../../Icon/Icon.js';
+import './VacationCard.css';
+
+export default class VacationCard {
+  constructor(vacationData) {
+    this.vacationData = vacationData;
+    this.chevronRight = new Icon({
+      svg: chevronRight,
+      options: { size: '24px', color: COLORS.DARK_GRAY },
+    });
+  }
+
+  html() {
+    return /* HTML */ `
+      <li class="vacation-card">
+        <div class="vacation-card-type-box">
+          <div class="vacation-card-icon">${this.vacationData.icon}</div>
+          <p class="vacation-card-type">${this.vacationData.type}</p>
+        </div>
+        <div class="vacation-card-info-box">
+          <p class="vacation-card-days">${this.vacationData.days}</p>
+          <div class="next-arrow-icon">${this.chevronRight.html()}</div>
+        </div>
+      </li>
+    `;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCards.css
+++ b/src/components/WorkManagement/VacationTab/VacationCards.css
@@ -1,0 +1,20 @@
+.vacation-cards-title {
+  padding-bottom: 30px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+@media (width >= 1024px) {
+  .vacation-cards-container {
+    padding: 0;
+    margin-top: 36px;
+    background-color: white;
+  }
+
+  .vacation-cards-list {
+    width: 100%;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationCards.js
+++ b/src/components/WorkManagement/VacationTab/VacationCards.js
@@ -1,0 +1,31 @@
+import './VacationCards.css';
+import VacationCard from './VacationCard.js';
+import { vacationArray } from '../../../utils/vacation.js';
+
+export default class VacationCards {
+  renderVacationCard() {
+    const $vacationCardsList = this.$vacationCardContainer.querySelector(
+      '.vacation-cards-list',
+    );
+
+    if ($vacationCardsList) {
+      $vacationCardsList.innerHTML = vacationArray
+        .map((vacationData) => new VacationCard(vacationData).html())
+        .join('');
+    }
+  }
+
+  render() {
+    this.$vacationCardContainer = document.querySelector(
+      '#main .vacation-cards-container',
+    );
+
+    this.$vacationCardContainer.innerHTML = /* HTML */ `
+      <div class="wrapper">
+        <h3 class="vacation-cards-title">휴가 신청하기</h3>
+        <ul class="vacation-cards-list"></ul>
+      </div>
+    `;
+    this.renderVacationCard();
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistories.css
+++ b/src/components/WorkManagement/VacationTab/VacationHistories.css
@@ -1,0 +1,24 @@
+.vacation-histories-header {
+  padding-bottom: 22px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.vacation-histories-title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+@media (width >= 1024px) {
+  .vacation-histories-header {
+    max-width: 300px;
+  }
+
+  .vacation-histories-container {
+    padding: 0;
+    margin-top: 48px;
+    margin-bottom: 48px;
+    background-color: white;
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistories.js
+++ b/src/components/WorkManagement/VacationTab/VacationHistories.js
@@ -1,0 +1,61 @@
+import './VacationHistories.css';
+import VacationHistory from './VacationHistory.js';
+import Select from '../../Select/Select.js';
+import { vacationTypes } from '../../../utils/vacation.js';
+import { storeInstance } from '../../Store.js';
+import { fetchVacationRequests } from '../../../api/endpoints/vacationRequests.js';
+
+export default class VacationHistories {
+  constructor() {
+    this.store = storeInstance;
+    this.isLoading = true;
+    this.VacationSelect = new Select({
+      contents: vacationTypes,
+      onSelect: (selectedItem) => console.log('Selected:', selectedItem),
+      roundedBorder: true,
+    });
+  }
+
+  async setVacation() {
+    if (!this.user) {
+      this.user = await this.store.getUser();
+    }
+    this.vacations = await fetchVacationRequests(this.user.employeeNumber);
+  }
+
+  async renderVacationHistories() {
+    const $vacationHistoriesList =
+      this.$vacationHistoriesContainer.querySelector(
+        '.vacation-histories-list',
+      );
+
+    if (!this.vacations) {
+      await this.setVacation();
+    }
+
+    if ($vacationHistoriesList) {
+      $vacationHistoriesList.innerHTML = this.vacations
+        .map((vacation) => new VacationHistory(vacation).html())
+        .join('');
+    }
+  }
+
+  async render() {
+    this.$vacationHistoriesContainer = document.querySelector(
+      '#main .vacation-histories-container',
+    );
+
+    this.$vacationHistoriesContainer.innerHTML = /* HTML */ `
+      <div class="wrapper">
+        <div class="vacation-histories-header">
+          <h3 class="vacation-histories-title">사용 기록</h3>
+          ${this.VacationSelect.html()}
+        </div>
+        <ul class="vacation-histories-list"></ul>
+      </div>
+    `;
+    await this.setVacation();
+    await this.renderVacationHistories();
+    this.VacationSelect.setEventListeners();
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistory.css
+++ b/src/components/WorkManagement/VacationTab/VacationHistory.css
@@ -1,0 +1,71 @@
+.vacation-history {
+  min-height: 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.vacation-history-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.vacation-history-type-box {
+  display: flex;
+  align-items: center;
+}
+
+.vacation-history-type-icon-box {
+  margin-right: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+}
+
+.vacation-history-type-icon {
+  margin-bottom: 5px;
+}
+
+.vacation-history-type {
+  margin-right: 10px;
+}
+
+.vacation-history-approval-status {
+  padding: 4px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  background-color: var(--color-primary);
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 4px;
+}
+
+.vacation-application-date {
+  font-size: 14px;
+  color: var(--color-darkest-gray);
+}
+
+@media (width >= 1024px) {
+  .vacation-history {
+    max-width: 300px;
+  }
+
+  .vacation-application-date {
+    position: relative;
+  }
+
+  .vacation-application-date::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: -27px;
+    transform: translate(0, -50%);
+    width: 2px;
+    height: 12px;
+    background-color: var(--color-light-gray);
+  }
+}

--- a/src/components/WorkManagement/VacationTab/VacationHistory.js
+++ b/src/components/WorkManagement/VacationTab/VacationHistory.js
@@ -1,0 +1,38 @@
+import { vacationArray } from '../../../utils/vacation.js';
+import './VacationHistory.css';
+
+export default class VacationHistory {
+  constructor(VacationHistoryData) {
+    this.vacationHistoryData = VacationHistoryData;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getIcon(vacationType) {
+    const vacation = vacationArray.find((v) => v.type === vacationType);
+    return vacation ? vacation.icon : '';
+  }
+
+  html() {
+    const icon = this.getIcon(this.vacationHistoryData.vacationType);
+    return /* HTML */ `
+      <li class="vacation-history">
+        <div class="vacation-history-container">
+          <div class="vacation-history-type-box">
+            <div class="vacation-history-type-icon-box">
+              <span class="vacation-history-type-icon">${icon}</span>
+            </div>
+            <p class="vacation-history-type">
+              ${this.vacationHistoryData.vacationType}
+            </p>
+          </div>
+          <span class="vacation-history-approval-status">
+            ${this.vacationHistoryData.approvalStatus}
+          </span>
+        </div>
+        <p class="vacation-application-date">
+          ${this.vacationHistoryData.vacationRequestDate}
+        </p>
+      </li>
+    `;
+  }
+}

--- a/src/components/WorkManagement/WorkingTab.css
+++ b/src/components/WorkManagement/WorkingTab.css
@@ -1,0 +1,19 @@
+.working-tab-title {
+  padding: 0 20px 30px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+@media (width >= 1024px) {
+  .working-tab-container {
+    padding: 0;
+    margin-top: 36px;
+    background-color: white;
+  }
+
+  .working-tab-title {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+}

--- a/src/components/WorkManagement/WorkingTab.js
+++ b/src/components/WorkManagement/WorkingTab.js
@@ -1,0 +1,85 @@
+import { fetchAttendances } from '../../api/endpoints/attendance.js';
+import {
+  calculateWeeklyCumulativeHours,
+  getDayOfWeek,
+} from '../../utils/userWork.js';
+
+import { storeInstance } from '../Store.js';
+import Table from '../Table/Table.js';
+import './WorkingTab.css';
+
+function formatValue(value) {
+  return value == null ? '-' : value;
+}
+
+export default class WorkingTab {
+  constructor() {
+    this.store = storeInstance;
+    this.attendances = [];
+    this.cumulativeWeeklyHours = 0;
+  }
+
+  async setWeeklyAttendances() {
+    if (!this.user) {
+      this.user = await this.store.getUser();
+    }
+    this.attendances = await fetchAttendances(this.user.employeeNumber);
+  }
+
+  renderTable = () => {
+    const weeklyCumulativeHours = calculateWeeklyCumulativeHours(
+      this.attendances,
+    );
+
+    const transformedAttendances = this.attendances.map((attendance) => {
+      const dayOfWeek = getDayOfWeek(attendance.date);
+      const { cumulativeHours } = weeklyCumulativeHours.find(
+        (wh) => wh.date === attendance.date,
+      );
+
+      return [
+        `${formatValue(attendance.date)} (${dayOfWeek})`,
+        formatValue(attendance.startTime),
+        formatValue(attendance.endTime),
+        formatValue(cumulativeHours),
+      ];
+    });
+
+    transformedAttendances.reverse();
+
+    this.table = new Table({
+      headers: ['날짜 (요일)', '출근 시각', '퇴근 시각', '주간 근무 시간'],
+      contents: transformedAttendances,
+      width: 25,
+    });
+
+    return this.table.html();
+  };
+
+  async renderWorkingHistory() {
+    this.$workingHistoryContainer = document.querySelector(
+      '.working-history-container',
+    );
+
+    if (!this.attendances.length) {
+      await this.setWeeklyAttendances();
+    }
+
+    if (this.$workingHistoryContainer) {
+      this.$workingHistoryContainer.innerHTML = this.renderTable();
+    }
+  }
+
+  async render() {
+    this.$workingTabContainer = document.querySelector(
+      '#main .working-tab-container',
+    );
+
+    this.$workingTabContainer.innerHTML = /* HTML */ `
+      <h3 class="working-tab-title">근무내역</h3>
+      <div class="working-history-container"></div>
+    `;
+    await this.setWeeklyAttendances();
+    this.renderWorkingHistory();
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,10 @@ button {
   padding-bottom: 70px;
 }
 
+.hidden {
+  display: none;
+}
+
 @media (width >= 1024px) {
   body {
     background-color: #fff;

--- a/src/pages/WorkManage/WorkManage.css
+++ b/src/pages/WorkManage/WorkManage.css
@@ -1,0 +1,61 @@
+.work-manage-header-container {
+  background-color: #fff;
+}
+
+.work-manage-menu-list {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  font-weight: 700;
+}
+
+.work-manage-menu-item {
+  height: 100%;
+  padding: 20px 0 15px;
+  color: var(--color-dark-gray);
+  cursor: pointer;
+}
+
+.work-manage-menu-item + .work-manage-menu-item {
+  margin-left: 28px;
+}
+
+.work-manage-menu-list li.active {
+  border-bottom: 2px solid var(--color-primary);
+  color: var(--color-black);
+}
+
+.vacation-histories-container {
+  padding: 30px 0;
+  margin-top: 12px;
+  background-color: white;
+}
+
+.vacation-cards-container {
+  padding: 30px 0;
+  margin-top: 12px;
+  background-color: white;
+}
+
+.working-tab-container {
+  padding: 30px 0;
+  margin-top: 12px;
+  background-color: white;
+}
+
+@media (width >= 1024px) {
+  .work-manage-menu-list {
+    position: relative;
+  }
+
+  .work-manage-menu-list::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 50%;
+    transform: translate(-50%, 0%);
+    width: calc(100% - (20px * 2));
+    height: 2px;
+    background-color: var(--color-light-gray);
+  }
+}

--- a/src/pages/WorkManage/WorkManage.js
+++ b/src/pages/WorkManage/WorkManage.js
@@ -1,19 +1,97 @@
+import './WorkManage.css';
 import Container from '../../components/Container.js';
 import Title from '../../components/Title/Title.js';
+import VacationCards from '../../components/WorkManagement/VacationTab/VacationCards.js';
+import VacationHistories from '../../components/WorkManagement/VacationTab/VacationHistories.js';
+import WorkingTab from '../../components/WorkManagement/WorkingTab.js';
 import { PATH_TITLE } from '../../utils/constants.js';
-import './WorkManage.css';
 
 export default class WorkManagePage extends Container {
   constructor() {
     super('#main');
-    this.Title = new Title({
-      title: PATH_TITLE.WORK_MANAGE,
-    });
+    this.Title = new Title({ title: PATH_TITLE.WORK_MANAGE });
+    this.vacationCards = new VacationCards();
+    this.vacationHistories = new VacationHistories();
+    this.workingTab = new WorkingTab();
   }
 
-  render() {
-    this.$container.innerHTML = `
-      ${this.Title.html()}
+  setupMenuInteraction() {
+    const menuItems = this.$container.querySelectorAll(
+      '.work-manage-menu-item',
+    );
+    menuItems.forEach((menuItem) =>
+      menuItem.addEventListener('click', (event) => {
+        menuItems.forEach((item) => item.classList.remove('active'));
+        event.currentTarget.classList.add('active');
+
+        this.renderContent(event.currentTarget.id);
+      }),
+    );
+  }
+
+  async renderContent(tabId) {
+    const sections = {
+      'work-management': [
+        this.$container.querySelector('.working-tab-container'),
+      ],
+      'vacation-management': [
+        this.$container.querySelector('.vacation-cards-container'),
+        this.$container.querySelector('.vacation-histories-container'),
+      ],
+    };
+
+    Object.values(sections).forEach((sectionArray) =>
+      sectionArray.forEach((section) => {
+        if (section) {
+          section.classList.add('hidden');
+        }
+      }),
+    );
+
+    const activeSections = sections[tabId];
+    if (activeSections) {
+      activeSections.forEach((section) => {
+        if (section) {
+          section.classList.remove('hidden');
+        }
+      });
+    }
+
+    switch (tabId) {
+      case 'work-management':
+        this.workingTab.render();
+        break;
+      case 'vacation-management':
+        await this.renderVacationTab();
+        break;
+      default:
+        await this.renderVacationTab();
+    }
+  }
+
+  renderVacationTab() {
+    this.vacationCards.render();
+    this.vacationHistories.render();
+  }
+
+  async render() {
+    this.$container.innerHTML = /* HTML */ `
+      <div class="work-manage-header-container">
+        ${this.Title.html()}
+        <ul class="work-manage-menu-list wrapper">
+          <li class="work-manage-menu-item" id="work-management">근무 관리</li>
+          <li class="work-manage-menu-item active" id="vacation-management">
+            휴가 관리
+          </li>
+        </ul>
+      </div>
+      <div id="work-manage-content" class="work-manage-content">
+        <section class="vacation-cards-container"></section>
+        <section class="vacation-histories-container"></section>
+        <section class="working-tab-container hidden"></section>
+      </div>
     `;
+    await this.renderVacationTab();
+    this.setupMenuInteraction();
   }
 }

--- a/src/utils/userWork.js
+++ b/src/utils/userWork.js
@@ -27,4 +27,65 @@ function setTodayWork(today) {
   };
 }
 
-export { calculateWeeklyWorkHours, setTodayWork };
+// 누적 근무 시간 관리 함수
+function calculateDailyWorkDuration(attendance) {
+  if (!attendance.startTime || !attendance.endTime) {
+    return 0;
+  }
+
+  const startTime = attendance.startTime.split(':');
+  const endTime = attendance.endTime.split(':');
+
+  const startHour = parseInt(startTime[0], 10);
+  const startMinute = parseInt(startTime[1], 10);
+  const endHour = parseInt(endTime[0], 10);
+  const endMinute = parseInt(endTime[1], 10);
+
+  const startTotalMinutes = startHour * 60 + startMinute;
+  const endTotalMinutes = endHour * 60 + endMinute;
+
+  const durationMinutes = endTotalMinutes - startTotalMinutes;
+  const durationHours = durationMinutes / 60;
+
+  return durationHours - 1;
+}
+
+function getDayOfWeek(dateStr) {
+  const date = new Date(dateStr);
+  const days = ['일', '월', '화', '수', '목', '금', '토'];
+  return days[date.getDay()];
+}
+
+function calculateWeeklyCumulativeHours(attendances) {
+  attendances.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+  const weeklyCumulativeHours = [];
+  let cumulativeHours = 0;
+
+  attendances.forEach((attendance, index) => {
+    const date = new Date(attendance.date);
+    const dayOfWeek = date.getDay();
+
+    if (dayOfWeek === 1 && index !== 0) {
+      cumulativeHours = 0;
+    }
+
+    const dailyHours = calculateDailyWorkDuration(attendance);
+    cumulativeHours += dailyHours;
+
+    weeklyCumulativeHours.push({
+      date: attendance.date,
+      cumulativeHours: Math.round(cumulativeHours * 10) / 10,
+    });
+  });
+
+  return weeklyCumulativeHours;
+}
+
+export {
+  calculateWeeklyWorkHours,
+  setTodayWork,
+  calculateDailyWorkDuration,
+  getDayOfWeek,
+  calculateWeeklyCumulativeHours,
+};

--- a/src/utils/vacation.js
+++ b/src/utils/vacation.js
@@ -1,0 +1,75 @@
+export const vacationArray = [
+  {
+    icon: '🌴',
+    type: '연차',
+    days: '17일',
+  },
+  {
+    icon: '💼',
+    type: '반차',
+    days: '3시간',
+  },
+  {
+    icon: '🤰🏻',
+    type: '출산 휴가',
+    days: '90일',
+  },
+  {
+    icon: '🫃🏻',
+    type: '배우자 출산 휴가',
+    days: '30일',
+  },
+  {
+    icon: '🎀',
+    type: '여성 휴가',
+    days: '1일',
+  },
+  {
+    icon: '👥',
+    type: '가족 돌봄 휴가',
+    days: '1일',
+  },
+  {
+    icon: '👤',
+    type: '기타 휴가',
+    days: '1일',
+  },
+];
+
+export const vacationTypes = [
+  '전체 휴가',
+  '연차',
+  '반차',
+  '출산 휴가',
+  '배우자 출산 휴가',
+  '여성 휴가',
+  '가족 돌봄 휴가',
+  '기타휴가',
+];
+
+export const vacationDaysOptions = [
+  '0일',
+  '1일',
+  '2일',
+  '3일',
+  '4일',
+  '5일',
+  '6일',
+  '7일',
+  '8일',
+];
+export const availableStartTimes = [
+  '00:00',
+  '09:00',
+  '10:00',
+  '11:00',
+  '12:00',
+  '13:00',
+  '14:00',
+  '15:00',
+  '16:00',
+  '17:00',
+  '18:00',
+];
+
+export const hourIncrements = ['0시간', '1시간', '2시간', '3시간', '4시간'];


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**휴가/근무 퍼블리싱, api 적용**


## 📋 작업 내용
- attendance, vacationRequest api 추가
- 공통 css hidden 클래스 추가: 탭메뉴 만들기 위해서 추가
- vacation 관련 배열 추가: select 관련 option들...
- 누적 근무 시간 관리 함수 추가
- 근무/휴가 퍼블리싱, api 추가 


## 🔧 변경 사항
- 데이터베이스 vactionRequest의 position 항목 삭제: 데이터베이스 오류가 생겨서 삭제했음.



## 📸 스크린샷 (선택 사항)

모바일
![Jul-11-2024 18-52-36](https://github.com/Dev-FE-1/idle-intranet-service/assets/89791868/f0a69810-bd21-476c-b17b-fc7c0cf835ee)

데스크탑
![Jul-11-2024 18-52-46](https://github.com/Dev-FE-1/idle-intranet-service/assets/89791868/4017a8ef-c7be-4989-9974-8143158255ca)



## 📄 기타

근무내역 꺼꾸로 바꾸는게 생각보다 시간이 오래걸렸음;;;;
그리고 구조를 한번 파악하니 수월하게 끝남.
기존에 있던 help 브랜치와 다르게 코드 구조도 다 바꿈.
모달은 추가하지 않았습니다. 코드가 더 많아질것 같고 시간도 더 걸릴것 같았음.
